### PR TITLE
chore: 添加Apache许可证并更新Go版本至1.25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ output/
 local_test/
 
 design
+
+.claude/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -48,7 +48,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent
@@ -104,8 +104,8 @@
           the Derivative Works; and
 
       (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute
-          must include a readable copy of the attribution notices contained
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
           within such NOTICE file, excluding those notices that do not
           pertain to any part of the Derivative Works, in at least one
           of the following places: within a NOTICE text file distributed
@@ -175,7 +175,18 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 kweaver-ai
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/examples/exchange-recovery/CHECKSUM
+++ b/examples/exchange-recovery/CHECKSUM
@@ -1,13 +1,13 @@
 # BKN Directory Checksum
-# generated: 2026-04-15T11:15:54+08:00
+# generated: 2026-04-28T16:11:51+08:00
 SKILL.md  sha256:84b912d3c20e2382
 action_type:browse_backup_emails  sha256:50962f766a0c52c9
-action_type:execute_recovery_task  sha256:341bb50d06af0bac
+action_type:execute_recovery_task  sha256:517def154f74ca7f
 action_type:find_backup_timepoints  sha256:ac7c4c61469192cd
-action_type:generate_recovery_report  sha256:ebbace8fe48c9759
-action_type:list_data_domains  sha256:71ff3c1a6c30e172
-action_type:list_exchange_servers  sha256:a65cab680e08ce20
-action_type:verify_exchange_availability  sha256:bbbd6c6decb3c33e
+action_type:generate_recovery_report  sha256:eacf655a053caeb0
+action_type:list_data_domains  sha256:c71016b013e56498
+action_type:list_exchange_servers  sha256:32fb7cae1af03711
+action_type:verify_exchange_availability  sha256:7126ab9f2eaebbbd
 concept_group:exchange  sha256:7a530fe32554fffb
 object_type:backup_timepoint  sha256:356e3c316fca6695
 object_type:data_domain  sha256:1c1f68b553a419a4

--- a/examples/exchange-recovery/action_types/execute_recovery_task.bkn
+++ b/examples/exchange-recovery/action_types/execute_recovery_task.bkn
@@ -68,6 +68,7 @@ operation: ==
 value: Pending
 ```
 
+
 ### Action Source
 
 | Type | BoxID | ToolID | McpID | ToolName |

--- a/examples/exchange-recovery/action_types/generate_recovery_report.bkn
+++ b/examples/exchange-recovery/action_types/generate_recovery_report.bkn
@@ -63,6 +63,7 @@ operation: ==
 value: success
 ```
 
+
 ### Action Source
 
 | Type | BoxID | ToolID | McpID | ToolName |

--- a/examples/exchange-recovery/action_types/list_data_domains.bkn
+++ b/examples/exchange-recovery/action_types/list_data_domains.bkn
@@ -70,6 +70,7 @@ operation: ==
 value: true
 ```
 
+
 ### Action Source
 
 | Type | BoxID | ToolID | McpID | ToolName |

--- a/examples/exchange-recovery/action_types/list_exchange_servers.bkn
+++ b/examples/exchange-recovery/action_types/list_exchange_servers.bkn
@@ -65,6 +65,7 @@ operation: ==
 value: Online
 ```
 
+
 ### Action Source
 
 | Type | BoxID | ToolID | McpID | ToolName |

--- a/examples/exchange-recovery/action_types/verify_exchange_availability.bkn
+++ b/examples/exchange-recovery/action_types/verify_exchange_availability.bkn
@@ -91,6 +91,7 @@ operation: ==
 value: 成功
 ```
 
+
 ### Action Source
 
 | Type | BoxID | ToolID | McpID | ToolName |

--- a/examples/exchange-recovery/network.bkn
+++ b/examples/exchange-recovery/network.bkn
@@ -13,6 +13,7 @@ business_domain: disaster_recovery
 
 支持Accident Request → Think → Risk Evaluate → Plan → Act → Report的完整恢复工作流。
 
+
 ## Network Overview
 
 ### Object Types

--- a/examples/k8s-network/CHECKSUM
+++ b/examples/k8s-network/CHECKSUM
@@ -1,8 +1,8 @@
 # BKN Directory Checksum
-# generated: 2026-04-15T11:15:54+08:00
+# generated: 2026-04-28T16:11:51+08:00
 SKILL.md  sha256:dc8001908e7adf8c
-action_type:cordon_node  sha256:0d4a4778abf86195
-action_type:restart_pod  sha256:6ee3ce23d9ab9e9e
+action_type:cordon_node  sha256:14875b9f754f7288
+action_type:restart_pod  sha256:fea7885498c45b4d
 concept_group:k8s  sha256:97c4d2aa63493fc4
 object_type:node  sha256:31097db12d607710
 object_type:pod  sha256:b37b865ed9e422db

--- a/examples/k8s-network/action_types/cordon_node.bkn
+++ b/examples/k8s-network/action_types/cordon_node.bkn
@@ -37,6 +37,7 @@ operation: ==
 value: NotReady
 ```
 
+
 ### Action Source
 
 | Type | BoxID | ToolID | McpID | ToolName |

--- a/examples/k8s-network/action_types/restart_pod.bkn
+++ b/examples/k8s-network/action_types/restart_pod.bkn
@@ -39,6 +39,7 @@ value:
   - Failed
 ```
 
+
 ### Action Source
 
 | Type | BoxID | ToolID | McpID | ToolName |

--- a/examples/k8s-network/network.bkn
+++ b/examples/k8s-network/network.bkn
@@ -12,6 +12,7 @@ business_domain: kubernetes
 
 Kubernetes 集群拓扑与运维操作的知识网络。
 
+
 ## Network Overview
 
 ### Object Types

--- a/examples/mock_system/CHECKSUM
+++ b/examples/mock_system/CHECKSUM
@@ -1,10 +1,10 @@
 # BKN Directory Checksum
-# generated: 2026-04-15T11:15:54+08:00
+# generated: 2026-04-28T16:11:51+08:00
 SKILL.md  sha256:08301dfb5f554f2a
 action_type:assess_department  sha256:ddcfd628ac7fb792
 action_type:delete_department  sha256:e96c729c1b099924
-action_type:new_employee_resource  sha256:94659a92fa92c137
-action_type:new_job  sha256:552689be3944de0b
+action_type:new_employee_resource  sha256:e2e2f18f07faa8bb
+action_type:new_job  sha256:de7adca4e7d59dee
 concept_group:employee_onboarding  sha256:a162a37192cb0198
 object_type:department  sha256:6f3c48e83821c8fe
 object_type:department_resource  sha256:913933ca03351f87
@@ -13,5 +13,5 @@ object_type:employee_resource  sha256:7084404af040425e
 object_type:relation  sha256:6a270aa2d5b77714
 object_type:skill  sha256:bf8ec1c95a85bbd2
 relation_type:emp_dept_resource  sha256:1c9a2007e3f32d8b
-relation_type:emp_skill  sha256:58273bf213057194
+relation_type:emp_skill  sha256:41187a1389b20af5
 relation_type:source_object_type_id  sha256:3517043fa1a34614

--- a/examples/mock_system/action_types/new_employee_resource.bkn
+++ b/examples/mock_system/action_types/new_employee_resource.bkn
@@ -29,6 +29,7 @@ operation: ==
 value: 0
 ```
 
+
 ### Action Source
 
 | Type | BoxID | ToolID | McpID | ToolName |

--- a/examples/mock_system/action_types/new_job.bkn
+++ b/examples/mock_system/action_types/new_job.bkn
@@ -29,6 +29,7 @@ operation: ==
 value: 0
 ```
 
+
 ### Action Source
 
 | Type | BoxID | ToolID | McpID | ToolName |

--- a/examples/mock_system/relation_types/emp_skill.bkn
+++ b/examples/mock_system/relation_types/emp_skill.bkn
@@ -28,6 +28,7 @@ sub_conds:
       - emp_003
 ```
 
+
 ### Target Condition
 
 ```yaml
@@ -39,4 +40,5 @@ sub_conds:
     value_from: const
     value: a0f20bd5-2532-4042-8122-382605ab4de4
 ```
+
 

--- a/examples/supplychain-hd/CHECKSUM
+++ b/examples/supplychain-hd/CHECKSUM
@@ -1,5 +1,5 @@
 # BKN Directory Checksum
-# generated: 2026-04-15T11:15:54+08:00
+# generated: 2026-04-28T16:11:51+08:00
 SKILL.md  sha256:d88bd5ba972bca41
 object_type:bom  sha256:f4f550e8d816d5e6
 object_type:forecast  sha256:e7f99dc1bfe45d96

--- a/examples/supplychain-hd/network.bkn
+++ b/examples/supplychain-hd/network.bkn
@@ -16,6 +16,7 @@ business_domain: supplychain
 4. 采购申请转化为采购订单并由供应商执行，生产计划指导工厂生产；
 5. 最终输出缺口数量及补货建议，支撑供应链决策。
 
+
 ## Network Overview
 
 ### Object Types

--- a/sdk/golang/bkn/checksum.go
+++ b/sdk/golang/bkn/checksum.go
@@ -160,7 +160,7 @@ func VerifyChecksumFileWithFS(fsys FileSystem, root string) (bool, []string) {
 	}
 
 	var errors []string
-	fsys.Walk(abs, func(path string, info fs.FileInfo, err error) error {
+	_ = fsys.Walk(abs, func(path string, info fs.FileInfo, err error) error {
 		if err != nil || info.IsDir() || fsys.Base(path) == ChecksumFileName {
 			return nil
 		}

--- a/sdk/golang/bkn/parser_test.go
+++ b/sdk/golang/bkn/parser_test.go
@@ -664,7 +664,7 @@ func TestParseFullNetwork(t *testing.T) {
 	// Create a temporary directory with full network structure
 	dir, err := os.MkdirTemp("", "bkn-full-network-*")
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	// Create network.bkn
 	networkContent := `---

--- a/sdk/golang/bkn/serialize.go
+++ b/sdk/golang/bkn/serialize.go
@@ -27,44 +27,44 @@ func encodeYAMLBlock(v any) string {
 // SerializeBknNetwork Serializes BknNetwork to BKN format
 func SerializeBknNetwork(doc *BknNetwork) string {
 	var sb strings.Builder
-	sb.WriteString("---\n")
-	sb.WriteString("type: knowledge_network\n")
-	sb.WriteString(fmt.Sprintf("id: %s\n", doc.ID))
-	sb.WriteString(fmt.Sprintf("name: %s\n", doc.Name))
-	sb.WriteString(fmt.Sprintf("tags: [%s]\n", strings.Join(doc.Tags, ", ")))
+	_, _ = fmt.Fprintf(&sb, "---\n")
+	_, _ = fmt.Fprintf(&sb, "type: knowledge_network\n")
+	_, _ = fmt.Fprintf(&sb, "id: %s\n", doc.ID)
+	_, _ = fmt.Fprintf(&sb, "name: %s\n", doc.Name)
+	_, _ = fmt.Fprintf(&sb, "tags: [%s]\n", strings.Join(doc.Tags, ", "))
 
 	if doc.Version != "" {
-		sb.WriteString(fmt.Sprintf("version: %s\n", doc.Version))
+		_, _ = fmt.Fprintf(&sb, "version: %s\n", doc.Version)
 	}
 	if doc.Branch != "" {
-		sb.WriteString(fmt.Sprintf("branch: %s\n", doc.Branch))
+		_, _ = fmt.Fprintf(&sb, "branch: %s\n", doc.Branch)
 	}
 	if doc.BusinessDomain != "" {
-		sb.WriteString(fmt.Sprintf("business_domain: %s\n", doc.BusinessDomain))
+		_, _ = fmt.Fprintf(&sb, "business_domain: %s\n", doc.BusinessDomain)
 	}
-	sb.WriteString("---\n\n")
+	_, _ = fmt.Fprintf(&sb, "---\n\n")
 
-	sb.WriteString(fmt.Sprintf("# %s\n\n", doc.Name))
+	_, _ = fmt.Fprintf(&sb, "# %s\n\n", doc.Name)
 	if doc.Description != "" {
-		sb.WriteString(doc.Description + "\n")
+		_, _ = fmt.Fprintf(&sb, "%s\n\n", doc.Description)
 	}
 
 	// Network Overview
-	sb.WriteString("\n## Network Overview\n")
+	_, _ = fmt.Fprintf(&sb, "\n## Network Overview\n")
 
-	sb.WriteString("\n### Object Types\n\n")
-	sb.WriteString("| ID | Name | File Path | Description |\n")
-	sb.WriteString("|----|------|-----------|-------------|\n")
+	_, _ = fmt.Fprintf(&sb, "\n### Object Types\n\n")
+	_, _ = fmt.Fprintf(&sb, "| ID | Name | File Path | Description |\n")
+	_, _ = fmt.Fprintf(&sb, "|----|------|-----------|-------------|\n")
 	if len(doc.ObjectTypes) > 0 {
 		sort.Slice(doc.ObjectTypes, func(i, j int) bool { return doc.ObjectTypes[i].ID < doc.ObjectTypes[j].ID })
 		for _, ot := range doc.ObjectTypes {
-			fmt.Fprintf(&sb, "| %s | %s | `object_types/%s.bkn` | %s |\n", ot.ID, ot.Name, ot.ID, ot.Summary)
+			_, _ = fmt.Fprintf(&sb, "| %s | %s | `object_types/%s.bkn` | %s |\n", ot.ID, ot.Name, ot.ID, ot.Summary)
 		}
 	}
 
-	sb.WriteString("\n### Relation Types\n\n")
-	sb.WriteString("| ID | Name | File Path | Description |\n")
-	sb.WriteString("|----|------|-----------|-------------|\n")
+	_, _ = fmt.Fprintf(&sb, "\n### Relation Types\n\n")
+	_, _ = fmt.Fprintf(&sb, "| ID | Name | File Path | Description |\n")
+	_, _ = fmt.Fprintf(&sb, "|----|------|-----------|-------------|\n")
 	if len(doc.RelationTypes) > 0 {
 		sort.Slice(doc.RelationTypes, func(i, j int) bool { return doc.RelationTypes[i].ID < doc.RelationTypes[j].ID })
 		for _, rt := range doc.RelationTypes {
@@ -72,9 +72,9 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 		}
 	}
 
-	sb.WriteString("\n### Action Types\n\n")
-	sb.WriteString("| ID | Name | File Path | Description |\n")
-	sb.WriteString("|----|------|-----------|-------------|\n")
+	_, _ = fmt.Fprintf(&sb, "\n### Action Types\n\n")
+	_, _ = fmt.Fprintf(&sb, "| ID | Name | File Path | Description |\n")
+	_, _ = fmt.Fprintf(&sb, "|----|------|-----------|-------------|\n")
 	if len(doc.ActionTypes) > 0 {
 		sort.Slice(doc.ActionTypes, func(i, j int) bool { return doc.ActionTypes[i].ID < doc.ActionTypes[j].ID })
 		for _, at := range doc.ActionTypes {
@@ -82,9 +82,9 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 		}
 	}
 
-	sb.WriteString("\n### Risk Types\n\n")
-	sb.WriteString("| ID | Name | File Path | Description |\n")
-	sb.WriteString("|----|------|-----------|-------------|\n")
+	_, _ = fmt.Fprintf(&sb, "\n### Risk Types\n\n")
+	_, _ = fmt.Fprintf(&sb, "| ID | Name | File Path | Description |\n")
+	_, _ = fmt.Fprintf(&sb, "|----|------|-----------|-------------|\n")
 	if len(doc.RiskTypes) > 0 {
 		sort.Slice(doc.RiskTypes, func(i, j int) bool { return doc.RiskTypes[i].ID < doc.RiskTypes[j].ID })
 		for _, rt := range doc.RiskTypes {
@@ -92,9 +92,9 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 		}
 	}
 
-	sb.WriteString("\n### Concept Groups\n\n")
-	sb.WriteString("| ID | Name | File Path | Description |\n")
-	sb.WriteString("|----|------|-----------|-------------|\n")
+	_, _ = fmt.Fprintf(&sb, "\n### Concept Groups\n\n")
+	_, _ = fmt.Fprintf(&sb, "| ID | Name | File Path | Description |\n")
+	_, _ = fmt.Fprintf(&sb, "|----|------|-----------|-------------|\n")
 	if len(doc.ConceptGroups) > 0 {
 		sort.Slice(doc.ConceptGroups, func(i, j int) bool { return doc.ConceptGroups[i].ID < doc.ConceptGroups[j].ID })
 		for _, cg := range doc.ConceptGroups {
@@ -144,14 +144,14 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 		dirs = append(dirs, dirEntry{"concept_groups", files})
 	}
 
-	sb.WriteString("\n## Directory Structure\n\n```\n.\n├── network.bkn\n├── SKILL.md\n├── CHECKSUM\n")
+	_, _ = fmt.Fprintf(&sb, "\n## Directory Structure\n\n```\n.\n├── network.bkn\n├── SKILL.md\n├── CHECKSUM\n")
 	for i, d := range dirs {
 		isLastDir := i == len(dirs)-1
 		dirPrefix, childPrefix := "├── ", "│   "
 		if isLastDir {
 			dirPrefix, childPrefix = "└── ", "    "
 		}
-		fmt.Fprintf(&sb, "%s%s/\n", dirPrefix, d.dir)
+		_, _ = fmt.Fprintf(&sb, "%s%s/\n", dirPrefix, d.dir)
 		for j, f := range d.files {
 			if j == len(d.files)-1 {
 				fmt.Fprintf(&sb, "%s└── %s\n", childPrefix, f)
@@ -160,7 +160,7 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 			}
 		}
 	}
-	sb.WriteString("```\n")
+	_, _ = fmt.Fprintf(&sb, "```\n")
 
 	return sb.String()
 }
@@ -168,91 +168,91 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 // SerializeObjectType Serializes BknObjectType to BKN format
 func SerializeObjectType(ot *BknObjectType) string {
 	var sb strings.Builder
-	sb.WriteString("---\n")
-	sb.WriteString("type: object_type\n")
-	sb.WriteString(fmt.Sprintf("id: %s\n", ot.ID))
-	sb.WriteString(fmt.Sprintf("name: %s\n", ot.Name))
-	sb.WriteString(fmt.Sprintf("tags: [%s]\n", strings.Join(ot.Tags, ", ")))
-	sb.WriteString("---\n\n")
+	_, _ = fmt.Fprintf(&sb, "---\n")
+	_, _ = fmt.Fprintf(&sb, "type: object_type\n")
+	_, _ = fmt.Fprintf(&sb, "id: %s\n", ot.ID)
+	_, _ = fmt.Fprintf(&sb, "name: %s\n", ot.Name)
+	_, _ = fmt.Fprintf(&sb, "tags: [%s]\n", strings.Join(ot.Tags, ", "))
+	_, _ = fmt.Fprintf(&sb, "---\n\n")
 
-	sb.WriteString(fmt.Sprintf("## ObjectType: %s\n\n", ot.Name))
+	_, _ = fmt.Fprintf(&sb, "## ObjectType: %s\n\n", ot.Name)
 	if ot.Description != "" {
-		sb.WriteString(ot.Description + "\n\n")
+		_, _ = fmt.Fprintf(&sb, "%s\n\n", ot.Description)
 	}
 
 	// Data Source
-	sb.WriteString("### Data Source\n\n")
-	sb.WriteString("| Type | ID | Name |\n")
-	sb.WriteString("|------|----|------|\n")
+	_, _ = fmt.Fprintf(&sb, "### Data Source\n\n")
+	_, _ = fmt.Fprintf(&sb, "| Type | ID | Name |\n")
+	_, _ = fmt.Fprintf(&sb, "|------|----|------|\n")
 	if ot.DataSource != nil {
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s |\n",
-			ot.DataSource.Type, ot.DataSource.ID, ot.DataSource.Name))
+		_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n",
+			ot.DataSource.Type, ot.DataSource.ID, ot.DataSource.Name)
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	// Data Properties
-	sb.WriteString("### Data Properties\n\n")
-	sb.WriteString("| Name | Display Name | Type | Description | Mapped Field |\n")
-	sb.WriteString("|------|--------------|------|-------------|--------------|\n")
+	_, _ = fmt.Fprintf(&sb, "### Data Properties\n\n")
+	_, _ = fmt.Fprintf(&sb, "| Name | Display Name | Type | Description | Mapped Field |\n")
+	_, _ = fmt.Fprintf(&sb, "|------|--------------|------|-------------|--------------|\n")
 	if len(ot.DataProperties) > 0 {
 		for _, dp := range ot.DataProperties {
-			sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s |\n",
-				dp.Name, dp.DisplayName, dp.Type, dp.Description, dp.MappedField))
+			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s |\n",
+				dp.Name, dp.DisplayName, dp.Type, dp.Description, dp.MappedField)
 		}
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	// Logic Properties
-	sb.WriteString("### Logic Properties\n\n")
+	_, _ = fmt.Fprintf(&sb, "### Logic Properties\n\n")
 	for _, lp := range ot.LogicProperties {
-		sb.WriteString(fmt.Sprintf("#### %s\n\n", lp.Name))
+		_, _ = fmt.Fprintf(&sb, "#### %s\n\n", lp.Name)
 
 		// Meta table
-		sb.WriteString("**Meta**\n\n")
-		sb.WriteString("| Display Name | Type | Description |\n")
-		sb.WriteString("|--------------|------|-------------|\n")
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s |\n\n", lp.DisplayName, lp.Type, lp.Description))
+		_, _ = fmt.Fprintf(&sb, "**Meta**\n\n")
+		_, _ = fmt.Fprintf(&sb, "| Display Name | Type | Description |\n")
+		_, _ = fmt.Fprintf(&sb, "|--------------|------|-------------|\n")
+		_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n\n", lp.DisplayName, lp.Type, lp.Description)
 
 		// Source table
-		sb.WriteString("**Source**\n\n")
-		sb.WriteString("| Source Type | Source ID | Source Name |\n")
-		sb.WriteString("|-------------|-----------|-------------|\n")
+		_, _ = fmt.Fprintf(&sb, "**Source**\n\n")
+		_, _ = fmt.Fprintf(&sb, "| Source Type | Source ID | Source Name |\n")
+		_, _ = fmt.Fprintf(&sb, "|-------------|-----------|-------------|\n")
 		if lp.DataSource != nil {
-			sb.WriteString(fmt.Sprintf("| %s | %s | %s |\n", lp.DataSource.Type, lp.DataSource.ID, lp.DataSource.Name))
+			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n", lp.DataSource.Type, lp.DataSource.ID, lp.DataSource.Name)
 		}
-		sb.WriteString("\n")
+		_, _ = fmt.Fprintf(&sb, "\n")
 
 		// Parameter table
-		sb.WriteString("**Parameters**\n\n")
-		sb.WriteString("| Name | Type | Source | Operation | ValueFrom | Value | Description |\n")
-		sb.WriteString("|------|------|--------|-----------|-----------|-------|-------------|\n")
+		_, _ = fmt.Fprintf(&sb, "**Parameters**\n\n")
+		_, _ = fmt.Fprintf(&sb, "| Name | Type | Source | Operation | ValueFrom | Value | Description |\n")
+		_, _ = fmt.Fprintf(&sb, "|------|------|--------|-----------|-----------|-------|-------------|\n")
 		for _, p := range lp.Parameters {
 			v := ""
 			if p.Value != nil {
 				v = fmt.Sprintf("%v", p.Value)
 			}
-			sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s |\n",
-				p.Name, p.Type, p.Source, p.Operation, p.ValueFrom, v, p.Description))
+			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s | %s | %s |\n",
+				p.Name, p.Type, p.Source, p.Operation, p.ValueFrom, v, p.Description)
 		}
-		sb.WriteString("\n")
+		_, _ = fmt.Fprintf(&sb, "\n")
 
 		// Analysis Dims table
-		sb.WriteString("**Analysis Dimensions**\n\n")
-		sb.WriteString("| Name | Display Name | Type | Description |\n")
-		sb.WriteString("|------|--------------|------|-------------|\n")
+		_, _ = fmt.Fprintf(&sb, "**Analysis Dimensions**\n\n")
+		_, _ = fmt.Fprintf(&sb, "| Name | Display Name | Type | Description |\n")
+		_, _ = fmt.Fprintf(&sb, "|------|--------------|------|-------------|\n")
 		for _, d := range lp.AnalysisDims {
-			sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n", d.Name, d.DisplayName, d.Type, d.Description))
+			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s |\n", d.Name, d.DisplayName, d.Type, d.Description)
 		}
-		sb.WriteString("\n")
+		_, _ = fmt.Fprintf(&sb, "\n")
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	// Keys section
-	sb.WriteString("### Keys\n\n")
-	sb.WriteString(fmt.Sprintf("Primary Keys: %s\n", strings.Join(ot.PrimaryKeys, ", ")))
-	sb.WriteString(fmt.Sprintf("Display Key: %s\n", ot.DisplayKey))
-	sb.WriteString(fmt.Sprintf("Incremental Key: %s\n", ot.IncrementalKey))
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "### Keys\n\n")
+	_, _ = fmt.Fprintf(&sb, "Primary Keys: %s\n", strings.Join(ot.PrimaryKeys, ", "))
+	_, _ = fmt.Fprintf(&sb, "Display Key: %s\n", ot.DisplayKey)
+	_, _ = fmt.Fprintf(&sb, "Incremental Key: %s\n", ot.IncrementalKey)
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	return sb.String()
 }
@@ -260,82 +260,82 @@ func SerializeObjectType(ot *BknObjectType) string {
 // SerializeRelationType Serializes BknRelationType to BKN format
 func SerializeRelationType(rt *BknRelationType) string {
 	var sb strings.Builder
-	sb.WriteString("---\n")
-	sb.WriteString("type: relation_type\n")
-	sb.WriteString(fmt.Sprintf("id: %s\n", rt.ID))
-	sb.WriteString(fmt.Sprintf("name: %s\n", rt.Name))
-	sb.WriteString(fmt.Sprintf("tags: [%s]\n", strings.Join(rt.Tags, ", ")))
-	sb.WriteString("---\n\n")
+	_, _ = fmt.Fprintf(&sb, "---\n")
+	_, _ = fmt.Fprintf(&sb, "type: relation_type\n")
+	_, _ = fmt.Fprintf(&sb, "id: %s\n", rt.ID)
+	_, _ = fmt.Fprintf(&sb, "name: %s\n", rt.Name)
+	_, _ = fmt.Fprintf(&sb, "tags: [%s]\n", strings.Join(rt.Tags, ", "))
+	_, _ = fmt.Fprintf(&sb, "---\n\n")
 
-	sb.WriteString(fmt.Sprintf("## RelationType: %s\n\n", rt.Name))
+	_, _ = fmt.Fprintf(&sb, "## RelationType: %s\n\n", rt.Name)
 	if rt.Description != "" {
-		sb.WriteString(rt.Description + "\n\n")
+		_, _ = fmt.Fprintf(&sb, "%s\n\n", rt.Description)
 	}
 
 	// Endpoint
-	sb.WriteString("### Endpoint\n\n")
-	sb.WriteString("| Source | Target | Type |\n")
-	sb.WriteString("|--------|--------|------|\n")
-	sb.WriteString(fmt.Sprintf("| %s | %s | %s |\n\n", rt.Endpoint.Source, rt.Endpoint.Target, rt.Endpoint.Type))
+	_, _ = fmt.Fprintf(&sb, "### Endpoint\n\n")
+	_, _ = fmt.Fprintf(&sb, "| Source | Target | Type |\n")
+	_, _ = fmt.Fprintf(&sb, "|--------|--------|------|\n")
+	_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n\n", rt.Endpoint.Source, rt.Endpoint.Target, rt.Endpoint.Type)
 
 	switch rt.Endpoint.Type {
 	case RELATION_MAPPING_TYPE_DIRECT:
 		// ### Mapping Rules — simple source→target property table
-		sb.WriteString("### Mapping Rules\n\n")
-		sb.WriteString("| Source Property | Target Property |\n")
-		sb.WriteString("|-----------------|-----------------|\n")
+		_, _ = fmt.Fprintf(&sb, "### Mapping Rules\n\n")
+		_, _ = fmt.Fprintf(&sb, "| Source Property | Target Property |\n")
+		_, _ = fmt.Fprintf(&sb, "|-----------------|-----------------|\n")
 		if rules, ok := rt.MappingRules.(DirectMappingRule); ok {
 			for _, r := range rules {
-				sb.WriteString(fmt.Sprintf("| %s | %s |\n", r.SourceProperty, r.TargetProperty))
+				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", r.SourceProperty, r.TargetProperty)
 			}
 		}
-		sb.WriteString("\n")
+		_, _ = fmt.Fprintf(&sb, "\n")
 
 	case RELATION_MAPPING_TYPE_DATA_VIEW:
 		// ### Mapping View — backing data source reference
-		sb.WriteString("### Mapping View\n\n")
-		sb.WriteString("| Type | ID |\n")
-		sb.WriteString("|------|----|\n")
+		_, _ = fmt.Fprintf(&sb, "### Mapping View\n\n")
+		_, _ = fmt.Fprintf(&sb, "| Type | ID |\n")
+		_, _ = fmt.Fprintf(&sb, "|------|----|\n")
 		if rules, ok := rt.MappingRules.(*InDirectMappingRule); ok {
 			if rules.BackingDataSource != nil {
-				sb.WriteString(fmt.Sprintf("| %s | %s |\n", rules.BackingDataSource.Type, rules.BackingDataSource.ID))
+				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", rules.BackingDataSource.Type, rules.BackingDataSource.ID)
 			}
-			sb.WriteString("\n")
+			_, _ = fmt.Fprintf(&sb, "\n")
 
 			// ### Source Mapping — source property → view property
-			sb.WriteString("### Source Mapping\n\n")
-			sb.WriteString("| Source Property | View Property |\n")
-			sb.WriteString("|-----------------|---------------|\n")
+			_, _ = fmt.Fprintf(&sb, "### Source Mapping\n\n")
+			_, _ = fmt.Fprintf(&sb, "| Source Property | View Property |\n")
+			_, _ = fmt.Fprintf(&sb, "|-----------------|---------------|\n")
 			for _, r := range rules.SourceMappingRules {
-				sb.WriteString(fmt.Sprintf("| %s | %s |\n", r.SourceProperty, r.TargetProperty))
+				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", r.SourceProperty, r.TargetProperty)
 			}
-			sb.WriteString("\n")
+			_, _ = fmt.Fprintf(&sb, "\n")
 
 			// ### Target Mapping — view property → target property
-			sb.WriteString("### Target Mapping\n\n")
-			sb.WriteString("| View Property | Target Property |\n")
-			sb.WriteString("|---------------|-----------------|\n")
+			_, _ = fmt.Fprintf(&sb, "### Target Mapping\n\n")
+			_, _ = fmt.Fprintf(&sb, "| View Property | Target Property |\n")
+			_, _ = fmt.Fprintf(&sb, "|---------------|-----------------|\n")
 			for _, r := range rules.TargetMappingRules {
-				sb.WriteString(fmt.Sprintf("| %s | %s |\n", r.SourceProperty, r.TargetProperty))
+				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", r.SourceProperty, r.TargetProperty)
 			}
-			sb.WriteString("\n")
+			_, _ = fmt.Fprintf(&sb, "\n")
 		} else {
-			sb.WriteString("\n")
+			_, _ = fmt.Fprintf(&sb, "\n")
 		}
 
 	case RELATION_MAPPING_TYPE_FILTERED_CROSS_JOIN:
 		if fcj, ok := rt.MappingRules.(*FilteredCrossJoinMapping); ok {
-			sb.WriteString("### Source Condition\n\n")
+			_, _ = fmt.Fprintf(&sb, "### Source Condition\n\n")
 			if fcj.SourceCondition != nil {
-				sb.WriteString(encodeYAMLBlock(fcj.SourceCondition))
+				_, _ = fmt.Fprintf(&sb, "%s\n", encodeYAMLBlock(fcj.SourceCondition))
 			}
-			sb.WriteString("\n")
+			_, _ = fmt.Fprintf(&sb, "\n")
 
-			sb.WriteString("### Target Condition\n\n")
+			_, _ = fmt.Fprintf(&sb, "### Target Condition\n\n")
 			if fcj.TargetCondition != nil {
-				sb.WriteString(encodeYAMLBlock(fcj.TargetCondition))
+				_, _ = fmt.Fprintf(&sb, "%s\n", encodeYAMLBlock(fcj.TargetCondition))
 			}
-			sb.WriteString("\n")
+			_, _ = fmt.Fprintf(&sb, "\n")
 		}
 	}
 
@@ -345,77 +345,77 @@ func SerializeRelationType(rt *BknRelationType) string {
 // SerializeActionType Serializes BknActionType to BKN format
 func SerializeActionType(at *BknActionType) string {
 	var sb strings.Builder
-	sb.WriteString("---\n")
-	sb.WriteString("type: action_type\n")
-	sb.WriteString(fmt.Sprintf("id: %s\n", at.ID))
-	sb.WriteString(fmt.Sprintf("name: %s\n", at.Name))
-	sb.WriteString(fmt.Sprintf("tags: [%s]\n", strings.Join(at.Tags, ", ")))
-	sb.WriteString(fmt.Sprintf("action_type: %s\n", at.ActionType))
-	sb.WriteString("---\n\n")
+	_, _ = fmt.Fprintf(&sb, "---\n")
+	_, _ = fmt.Fprintf(&sb, "type: action_type\n")
+	_, _ = fmt.Fprintf(&sb, "id: %s\n", at.ID)
+	_, _ = fmt.Fprintf(&sb, "name: %s\n", at.Name)
+	_, _ = fmt.Fprintf(&sb, "tags: [%s]\n", strings.Join(at.Tags, ", "))
+	_, _ = fmt.Fprintf(&sb, "action_type: %s\n", at.ActionType)
+	_, _ = fmt.Fprintf(&sb, "---\n\n")
 
-	sb.WriteString(fmt.Sprintf("## ActionType: %s\n\n", at.Name))
+	_, _ = fmt.Fprintf(&sb, "## ActionType: %s\n\n", at.Name)
 	if at.Description != "" {
-		sb.WriteString(at.Description + "\n\n")
+		_, _ = fmt.Fprintf(&sb, "%s\n\n", at.Description)
 	}
 
 	// Bound Object
-	sb.WriteString("### Bound Object\n\n")
-	sb.WriteString("| Bound Object |\n")
-	sb.WriteString("|--------------|\n")
+	_, _ = fmt.Fprintf(&sb, "### Bound Object\n\n")
+	_, _ = fmt.Fprintf(&sb, "| Bound Object |\n")
+	_, _ = fmt.Fprintf(&sb, "|--------------|\n")
 	if at.BoundObject != "" {
-		sb.WriteString(fmt.Sprintf("| %s |\n", at.BoundObject))
+		_, _ = fmt.Fprintf(&sb, "| %s |\n", at.BoundObject)
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	// Affect Object
-	sb.WriteString("### Affect Object\n\n")
-	sb.WriteString("| Affect Object | Affect Description |\n")
-	sb.WriteString("|---------------|--------------------|\n")
+	_, _ = fmt.Fprintf(&sb, "### Affect Object\n\n")
+	_, _ = fmt.Fprintf(&sb, "| Affect Object | Affect Description |\n")
+	_, _ = fmt.Fprintf(&sb, "|---------------|--------------------|\n")
 	if at.AffectObject != nil {
-		sb.WriteString(fmt.Sprintf("| %s | %s |\n", at.AffectObject.ObjectType, at.AffectObject.Description))
+		_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", at.AffectObject.ObjectType, at.AffectObject.Description)
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	// Trigger Condition
-	sb.WriteString("### Trigger Condition\n\n")
+	_, _ = fmt.Fprintf(&sb, "### Trigger Condition\n\n")
 	if at.TriggerCondition != nil {
-		sb.WriteString(encodeYAMLBlock(at.TriggerCondition))
+		_, _ = fmt.Fprintf(&sb, "%s\n", encodeYAMLBlock(at.TriggerCondition))
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	// Action Source
-	sb.WriteString("### Action Source\n\n")
-	sb.WriteString("| Type | BoxID | ToolID | McpID | ToolName |\n")
-	sb.WriteString("|------|-------|--------|-------|----------|\n")
+	_, _ = fmt.Fprintf(&sb, "### Action Source\n\n")
+	_, _ = fmt.Fprintf(&sb, "| Type | BoxID | ToolID | McpID | ToolName |\n")
+	_, _ = fmt.Fprintf(&sb, "|------|-------|--------|-------|----------|\n")
 	if at.ActionSource != nil && at.ActionSource.Type != "" {
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s |\n",
+		_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s |\n",
 			at.ActionSource.Type, at.ActionSource.BoxID, at.ActionSource.ToolID,
-			at.ActionSource.McpID, at.ActionSource.ToolName))
+			at.ActionSource.McpID, at.ActionSource.ToolName)
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	// Parameter Binding
-	sb.WriteString("### Parameter Binding\n\n")
-	sb.WriteString("| Name | Type | Source | Operation | ValueFrom | Value | Description |\n")
-	sb.WriteString("|------|------|--------|-----------|-----------|-------|-------------|\n")
+	_, _ = fmt.Fprintf(&sb, "### Parameter Binding\n\n")
+	_, _ = fmt.Fprintf(&sb, "| Name | Type | Source | Operation | ValueFrom | Value | Description |\n")
+	_, _ = fmt.Fprintf(&sb, "|------|------|--------|-----------|-----------|-------|-------------|\n")
 	for _, p := range at.Parameters {
 		v := p.Value
 		if v == nil {
 			v = ""
 		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s |\n",
-			p.Name, p.Type, p.Source, p.Operation, p.ValueFrom, v, p.Description))
+		_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s | %s | %s |\n",
+			p.Name, p.Type, p.Source, p.Operation, p.ValueFrom, v, p.Description)
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	// Schedule
-	sb.WriteString("### Schedule\n\n")
-	sb.WriteString("| Type | Expression |\n")
-	sb.WriteString("|------|------------|\n")
+	_, _ = fmt.Fprintf(&sb, "### Schedule\n\n")
+	_, _ = fmt.Fprintf(&sb, "| Type | Expression |\n")
+	_, _ = fmt.Fprintf(&sb, "|------|------------|\n")
 	if at.Schedule != nil && at.Schedule.Type != "" {
-		sb.WriteString(fmt.Sprintf("| %s | %s |\n", at.Schedule.Type, at.Schedule.Expression))
+		_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", at.Schedule.Type, at.Schedule.Expression)
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	return sb.String()
 }
@@ -423,16 +423,16 @@ func SerializeActionType(at *BknActionType) string {
 // SerializeRiskType Serializes BknRiskType to BKN format
 func SerializeRiskType(rt *BknRiskType) string {
 	var sb strings.Builder
-	sb.WriteString("---\n")
-	sb.WriteString("type: risk_type\n")
-	sb.WriteString(fmt.Sprintf("id: %s\n", rt.ID))
-	sb.WriteString(fmt.Sprintf("name: %s\n", rt.Name))
-	sb.WriteString(fmt.Sprintf("tags: [%s]\n", strings.Join(rt.Tags, ", ")))
-	sb.WriteString("---\n\n")
+	_, _ = fmt.Fprintf(&sb, "---\n")
+	_, _ = fmt.Fprintf(&sb, "type: risk_type\n")
+	_, _ = fmt.Fprintf(&sb, "id: %s\n", rt.ID)
+	_, _ = fmt.Fprintf(&sb, "name: %s\n", rt.Name)
+	_, _ = fmt.Fprintf(&sb, "tags: [%s]\n", strings.Join(rt.Tags, ", "))
+	_, _ = fmt.Fprintf(&sb, "---\n\n")
 
-	sb.WriteString(fmt.Sprintf("## RiskType: %s\n\n", rt.Name))
+	_, _ = fmt.Fprintf(&sb, "## RiskType: %s\n\n", rt.Name)
 	if rt.Description != "" {
-		sb.WriteString(rt.Description + "\n\n")
+		_, _ = fmt.Fprintf(&sb, "%s\n\n", rt.Description)
 	}
 
 	return sb.String()
@@ -442,21 +442,20 @@ func SerializeRiskType(rt *BknRiskType) string {
 // otIndex maps ObjectType ID → *BknObjectType for Name/Description lookup.
 func SerializeConceptGroup(cg *BknConceptGroup, otIndex map[string]*BknObjectType) string {
 	var sb strings.Builder
-	sb.WriteString("---\n")
-	sb.WriteString("type: concept_group\n")
-	sb.WriteString(fmt.Sprintf("id: %s\n", cg.ID))
-	sb.WriteString(fmt.Sprintf("name: %s\n", cg.Name))
-	sb.WriteString(fmt.Sprintf("tags: [%s]\n", strings.Join(cg.Tags, ", ")))
-	sb.WriteString("---\n\n")
+	_, _ = fmt.Fprintf(&sb, "---\n")
+	_, _ = fmt.Fprintf(&sb, "type: concept_group\n")
+	_, _ = fmt.Fprintf(&sb, "id: %s\n", cg.ID)
+	_, _ = fmt.Fprintf(&sb, "name: %s\n", cg.Name)
+	_, _ = fmt.Fprintf(&sb, "tags: [%s]\n", strings.Join(cg.Tags, ", "))
+	_, _ = fmt.Fprintf(&sb, "---\n\n")
 
-	sb.WriteString(fmt.Sprintf("## ConceptGroup: %s\n\n", cg.Name))
+	_, _ = fmt.Fprintf(&sb, "## ConceptGroup: %s\n\n", cg.Name)
 	if cg.Description != "" {
-		sb.WriteString(cg.Description + "\n\n")
+		_, _ = fmt.Fprintf(&sb, "%s\n\n", cg.Description)
 	}
-
-	sb.WriteString("### Object Types\n\n")
-	sb.WriteString("| ID | Name | Description |\n")
-	sb.WriteString("|----|------|-------------|\n")
+	_, _ = fmt.Fprintf(&sb, "### Object Types\n\n")
+	_, _ = fmt.Fprintf(&sb, "| ID | Name | Description |\n")
+	_, _ = fmt.Fprintf(&sb, "|----|------|-------------|\n")
 	if len(cg.ObjectTypes) > 0 {
 		ids := append([]string(nil), cg.ObjectTypes...)
 		sort.Strings(ids)
@@ -466,10 +465,10 @@ func SerializeConceptGroup(cg *BknConceptGroup, otIndex map[string]*BknObjectTyp
 				name = ot.Name
 				desc = ot.Summary
 			}
-			sb.WriteString(fmt.Sprintf("| %s | %s | %s |\n", id, name, desc))
+			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n", id, name, desc)
 		}
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	return sb.String()
 }

--- a/sdk/golang/bkn/tar_test.go
+++ b/sdk/golang/bkn/tar_test.go
@@ -21,12 +21,12 @@ import (
 func TestWriteTarEntry_Success(t *testing.T) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	defer tw.Close()
+	defer func() { _ = tw.Close() }()
 
 	content := []byte("test content")
 	err := writeTarEntry(tw, "test.bkn", content, time.Now())
 	require.NoError(t, err)
-	tw.Close()
+	_ = tw.Close()
 
 	// Verify tar can be read
 	tr := tar.NewReader(&buf)
@@ -103,9 +103,9 @@ func TestExtractTarToMemory_SingleNetworkFile(t *testing.T) {
 	tw := tar.NewWriter(&buf)
 
 	content := []byte("---\ntype: network\nid: test-network\nname: Test Network\n---\n")
-	tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(content)), Mode: 0644})
-	tw.Write(content)
-	tw.Close()
+	_ = tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(content)), Mode: 0644})
+	_, _ = tw.Write(content)
+	_ = tw.Close()
 
 	mfs, rootDir, err := ExtractTarToMemory(&buf)
 	require.NoError(t, err)
@@ -132,10 +132,10 @@ func TestExtractTarToMemory_WithSubdirectories(t *testing.T) {
 
 	for name, content := range files {
 		data := []byte(content)
-		tw.WriteHeader(&tar.Header{Name: name, Size: int64(len(data)), Mode: 0644})
-		tw.Write(data)
+		_ = tw.WriteHeader(&tar.Header{Name: name, Size: int64(len(data)), Mode: 0644})
+		_, _ = tw.Write(data)
 	}
-	tw.Close()
+	_ = tw.Close()
 
 	mfs, rootDir, err := ExtractTarToMemory(&buf)
 	require.NoError(t, err)
@@ -151,7 +151,7 @@ func TestExtractTarToMemory_WithSubdirectories(t *testing.T) {
 func TestExtractTarToMemory_EmptyTar(t *testing.T) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	tw.Close()
+	_ = tw.Close()
 
 	_, _, err := ExtractTarToMemory(&buf)
 	assert.Error(t, err)
@@ -163,9 +163,9 @@ func TestExtractTarToMemory_NoNetworkFile(t *testing.T) {
 	tw := tar.NewWriter(&buf)
 
 	content := []byte("---\ntype: object_type\nid: pod\n---\n")
-	tw.WriteHeader(&tar.Header{Name: "object_types/pod.bkn", Size: int64(len(content)), Mode: 0644})
-	tw.Write(content)
-	tw.Close()
+	_ = tw.WriteHeader(&tar.Header{Name: "object_types/pod.bkn", Size: int64(len(content)), Mode: 0644})
+	_, _ = tw.Write(content)
+	_ = tw.Close()
 
 	_, _, err := ExtractTarToMemory(&buf)
 	assert.Error(t, err)
@@ -177,9 +177,9 @@ func TestExtractTarToMemory_NestedRoot(t *testing.T) {
 	tw := tar.NewWriter(&buf)
 
 	content := []byte("---\ntype: network\nid: test\n---\n")
-	tw.WriteHeader(&tar.Header{Name: "myapp/network.bkn", Size: int64(len(content)), Mode: 0644})
-	tw.Write(content)
-	tw.Close()
+	_ = tw.WriteHeader(&tar.Header{Name: "myapp/network.bkn", Size: int64(len(content)), Mode: 0644})
+	_, _ = tw.Write(content)
+	_ = tw.Close()
 
 	mfs, rootDir, err := ExtractTarToMemory(&buf)
 	require.NoError(t, err)
@@ -198,13 +198,13 @@ func TestExtractTarToMemory_SkipsAppleDouble(t *testing.T) {
 	podContent := []byte("---\ntype: object_type\nid: pod\nname: Pod\n---\n")
 	appleDoubleContent := []byte("invalid apple double")
 
-	tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
-	tw.Write(networkContent)
-	tw.WriteHeader(&tar.Header{Name: "object_types/pod.bkn", Size: int64(len(podContent)), Mode: 0644})
-	tw.Write(podContent)
-	tw.WriteHeader(&tar.Header{Name: "object_types/._pod.bkn", Size: int64(len(appleDoubleContent)), Mode: 0644})
-	tw.Write(appleDoubleContent)
-	tw.Close()
+	_ = tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
+	_, _ = tw.Write(networkContent)
+	_ = tw.WriteHeader(&tar.Header{Name: "object_types/pod.bkn", Size: int64(len(podContent)), Mode: 0644})
+	_, _ = tw.Write(podContent)
+	_ = tw.WriteHeader(&tar.Header{Name: "object_types/._pod.bkn", Size: int64(len(appleDoubleContent)), Mode: 0644})
+	_, _ = tw.Write(appleDoubleContent)
+	_ = tw.Close()
 
 	rawBytes := buf.Bytes()
 
@@ -435,13 +435,13 @@ func TestComputeChecksumFromTar_ValidTar(t *testing.T) {
 	tw := tar.NewWriter(&buf)
 
 	networkContent := []byte("---\ntype: network\nid: test\n---\n")
-	tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
-	tw.Write(networkContent)
+	_ = tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
+	_, _ = tw.Write(networkContent)
 
 	objContent := []byte("---\ntype: object_type\nid: pod\n---\n")
-	tw.WriteHeader(&tar.Header{Name: "object_types/pod.bkn", Size: int64(len(objContent)), Mode: 0644})
-	tw.Write(objContent)
-	tw.Close()
+	_ = tw.WriteHeader(&tar.Header{Name: "object_types/pod.bkn", Size: int64(len(objContent)), Mode: 0644})
+	_, _ = tw.Write(objContent)
+	_ = tw.Close()
 
 	checksumMap, err := ComputeChecksumFromTar(&buf)
 	require.NoError(t, err)
@@ -456,13 +456,13 @@ func TestGenerateChecksumFromTar_ValidTar(t *testing.T) {
 	tw := tar.NewWriter(&buf)
 
 	networkContent := []byte("---\ntype: network\nid: test\n---\n")
-	tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
-	tw.Write(networkContent)
+	_ = tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
+	_, _ = tw.Write(networkContent)
 
 	objContent := []byte("---\ntype: object_type\nid: pod\n---\n")
-	tw.WriteHeader(&tar.Header{Name: "object_types/pod.bkn", Size: int64(len(objContent)), Mode: 0644})
-	tw.Write(objContent)
-	tw.Close()
+	_ = tw.WriteHeader(&tar.Header{Name: "object_types/pod.bkn", Size: int64(len(objContent)), Mode: 0644})
+	_, _ = tw.Write(objContent)
+	_ = tw.Close()
 
 	checksum, err := GenerateChecksumFromTar(&buf)
 	require.NoError(t, err)
@@ -476,9 +476,9 @@ func TestComputeChecksumFromTar_NoNetworkFile(t *testing.T) {
 	tw := tar.NewWriter(&buf)
 
 	content := []byte("---\ntype: object_type\nid: pod\n---\n")
-	tw.WriteHeader(&tar.Header{Name: "object_types/pod.bkn", Size: int64(len(content)), Mode: 0644})
-	tw.Write(content)
-	tw.Close()
+	_ = tw.WriteHeader(&tar.Header{Name: "object_types/pod.bkn", Size: int64(len(content)), Mode: 0644})
+	_, _ = tw.Write(content)
+	_ = tw.Close()
 
 	_, err := ComputeChecksumFromTar(&buf)
 	assert.Error(t, err)
@@ -490,9 +490,9 @@ func TestVerifyChecksumFromTar_Valid(t *testing.T) {
 	tw := tar.NewWriter(&buf)
 
 	networkContent := []byte("---\ntype: network\nid: test\n---\n")
-	tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
-	tw.Write(networkContent)
-	tw.Close()
+	_ = tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
+	_, _ = tw.Write(networkContent)
+	_ = tw.Close()
 
 	checksum, err := GenerateChecksumFromTar(&buf)
 	require.NoError(t, err)
@@ -501,13 +501,13 @@ func TestVerifyChecksumFromTar_Valid(t *testing.T) {
 	var buf2 bytes.Buffer
 	tw2 := tar.NewWriter(&buf2)
 
-	tw2.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
-	tw2.Write(networkContent)
+	_ = tw2.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
+	_, _ = tw2.Write(networkContent)
 
 	checksumContent := []byte(checksum)
-	tw2.WriteHeader(&tar.Header{Name: "CHECKSUM", Size: int64(len(checksumContent)), Mode: 0644})
-	tw2.Write(checksumContent)
-	tw2.Close()
+	_ = tw2.WriteHeader(&tar.Header{Name: "CHECKSUM", Size: int64(len(checksumContent)), Mode: 0644})
+	_, _ = tw2.Write(checksumContent)
+	_ = tw2.Close()
 
 	// Verify
 	ok, errs := VerifyChecksumFromTar(&buf2)
@@ -520,14 +520,14 @@ func TestVerifyChecksumFromTar_InvalidChecksum(t *testing.T) {
 	tw := tar.NewWriter(&buf)
 
 	networkContent := []byte("---\ntype: network\nid: test\n---\n")
-	tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
-	tw.Write(networkContent)
+	_ = tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(networkContent)), Mode: 0644})
+	_, _ = tw.Write(networkContent)
 
 	// Add invalid checksum
 	invalidChecksum := []byte("# Checksum\nnetwork  sha256:invalid123\n")
-	tw.WriteHeader(&tar.Header{Name: "CHECKSUM", Size: int64(len(invalidChecksum)), Mode: 0644})
-	tw.Write(invalidChecksum)
-	tw.Close()
+	_ = tw.WriteHeader(&tar.Header{Name: "CHECKSUM", Size: int64(len(invalidChecksum)), Mode: 0644})
+	_, _ = tw.Write(invalidChecksum)
+	_ = tw.Close()
 
 	ok, errs := VerifyChecksumFromTar(&buf)
 	assert.False(t, ok)
@@ -539,9 +539,9 @@ func TestVerifyChecksumFromTar_MissingChecksumFile(t *testing.T) {
 	tw := tar.NewWriter(&buf)
 
 	content := []byte("---\ntype: network\nid: test\n---\n")
-	tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(content)), Mode: 0644})
-	tw.Write(content)
-	tw.Close()
+	_ = tw.WriteHeader(&tar.Header{Name: "network.bkn", Size: int64(len(content)), Mode: 0644})
+	_, _ = tw.Write(content)
+	_ = tw.Close()
 
 	ok, errs := VerifyChecksumFromTar(&buf)
 	assert.False(t, ok)

--- a/sdk/golang/bkn/tar_writer.go
+++ b/sdk/golang/bkn/tar_writer.go
@@ -26,7 +26,7 @@ import (
 // - CHECKSUM (auto-generated)
 func WriteNetworkToTar(doc *BknNetwork, w io.Writer) error {
 	tw := tar.NewWriter(w)
-	defer tw.Close()
+	defer func() { _ = tw.Close() }()
 
 	now := time.Now()
 	mfs := NewMemoryFileSystem()
@@ -123,113 +123,110 @@ func generateSkillMd(doc *BknNetwork) string {
 	var sb strings.Builder
 
 	// Header
-	sb.WriteString(fmt.Sprintf("# %s - Agent 使用指南\n\n", fm.Name))
-	sb.WriteString(fmt.Sprintf("> **网络ID**: %s  \n", fm.ID))
-	sb.WriteString(fmt.Sprintf("> **版本**: %s  \n", fm.Version))
+	_, _ = fmt.Fprintf(&sb, "# %s - Agent 使用指南\n\n", fm.Name)
+	_, _ = fmt.Fprintf(&sb, "> **网络ID**: %s  \n", fm.ID)
+	_, _ = fmt.Fprintf(&sb, "> **版本**: %s  \n", fm.Version)
 	if len(fm.Tags) > 0 {
-		sb.WriteString(fmt.Sprintf("> **标签**: %s  \n", strings.Join(fm.Tags, ", ")))
+		_, _ = fmt.Fprintf(&sb, "> **标签**: %s  \n", strings.Join(fm.Tags, ", "))
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
 	// Overview
-	sb.WriteString("## 网络概览\n\n")
+	_, _ = fmt.Fprintf(&sb, "## 网络概览\n\n")
 	if doc.Description != "" {
-		sb.WriteString(doc.Description)
-		sb.WriteString("\n\n")
+		_, _ = fmt.Fprintf(&sb, "%s\n\n", doc.Description)
 	}
 
 	// Objects table
 	if len(doc.ObjectTypes) > 0 {
-		sb.WriteString("### 核心对象\n\n")
-		sb.WriteString("| 对象 | 文件路径 | 说明 |\n")
-		sb.WriteString("|------|----------|------|\n")
+		_, _ = fmt.Fprintf(&sb, "### 核心对象\n\n")
+		_, _ = fmt.Fprintf(&sb, "| 对象 | 文件路径 | 说明 |\n")
+		_, _ = fmt.Fprintf(&sb, "|------|----------|------|\n")
 		ots := append([]*BknObjectType(nil), doc.ObjectTypes...)
 		sort.Slice(ots, func(i, j int) bool { return ots[i].ID < ots[j].ID })
 		for _, ot := range ots {
 			path := "object_types/" + ot.ID + ".bkn"
-			sb.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n", ot.Name, path, ot.Description))
+			_, _ = fmt.Fprintf(&sb, "| %s | `%s` | %s |\n", ot.Name, path, ot.Description)
 		}
-		sb.WriteString("\n")
+		_, _ = fmt.Fprintf(&sb, "\n")
 	}
 
 	// Relations table
 	if len(doc.RelationTypes) > 0 {
-		sb.WriteString("### 核心关系\n\n")
-		sb.WriteString("| 关系 | 文件路径 | 说明 |\n")
-		sb.WriteString("|------|----------|------|\n")
+		_, _ = fmt.Fprintf(&sb, "### 核心关系\n\n")
+		_, _ = fmt.Fprintf(&sb, "| 关系 | 文件路径 | 说明 |\n")
+		_, _ = fmt.Fprintf(&sb, "|------|----------|------|\n")
 		rts := append([]*BknRelationType(nil), doc.RelationTypes...)
 		sort.Slice(rts, func(i, j int) bool { return rts[i].ID < rts[j].ID })
 		for _, rt := range rts {
 			path := "relation_types/" + rt.ID + ".bkn"
-			sb.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n", rt.Name, path, rt.Description))
+			_, _ = fmt.Fprintf(&sb, "| %s | `%s` | %s |\n", rt.Name, path, rt.Description)
 		}
-		sb.WriteString("\n")
+		_, _ = fmt.Fprintf(&sb, "\n")
 	}
 
 	// Actions table
 	if len(doc.ActionTypes) > 0 {
-		sb.WriteString("### 可用行动\n\n")
-		sb.WriteString("| 行动 | 文件路径 | 说明 |\n")
-		sb.WriteString("|------|----------|------|\n")
+		_, _ = fmt.Fprintf(&sb, "### 可用行动\n\n")
+		_, _ = fmt.Fprintf(&sb, "| 行动 | 文件路径 | 说明 |\n")
+		_, _ = fmt.Fprintf(&sb, "|------|----------|------|\n")
 		ats := append([]*BknActionType(nil), doc.ActionTypes...)
 		sort.Slice(ats, func(i, j int) bool { return ats[i].ID < ats[j].ID })
 		for _, at := range ats {
 			path := "action_types/" + at.ID + ".bkn"
-			sb.WriteString(fmt.Sprintf("| %s | `%s` | %s |\n", at.Name, path, at.Description))
+			_, _ = fmt.Fprintf(&sb, "| %s | `%s` | %s |\n", at.Name, path, at.Description)
 		}
-		sb.WriteString("\n")
+		_, _ = fmt.Fprintf(&sb, "\n")
 	}
 
 	// Directory structure
-	sb.WriteString("## 目录结构\n\n")
-	sb.WriteString("```\n")
-	sb.WriteString(".\n")
-	sb.WriteString("├── network.bkn\n")
-	sb.WriteString("├── SKILL.md\n")
-	sb.WriteString("├── CHECKSUM\n")
+	_, _ = fmt.Fprintf(&sb, "## 目录结构\n\n")
+	_, _ = fmt.Fprintf(&sb, "```\n")
+	_, _ = fmt.Fprintf(&sb, ".\n")
+	_, _ = fmt.Fprintf(&sb, "├── network.bkn\n")
+	_, _ = fmt.Fprintf(&sb, "├── SKILL.md\n")
+	_, _ = fmt.Fprintf(&sb, "├── CHECKSUM\n")
 	if len(doc.ObjectTypes) > 0 {
-		sb.WriteString("├── object_types/\n")
+		_, _ = fmt.Fprintf(&sb, "├── object_types/\n")
 	}
 	if len(doc.RelationTypes) > 0 {
-		sb.WriteString("├── relation_types/\n")
+		_, _ = fmt.Fprintf(&sb, "├── relation_types/\n")
 	}
 	if len(doc.ActionTypes) > 0 {
-		sb.WriteString("└── action_types/\n")
+		_, _ = fmt.Fprintf(&sb, "└── action_types/\n")
 	}
-	sb.WriteString("```\n\n")
-
+	_, _ = fmt.Fprintf(&sb, "```\n\n")
 	// Usage suggestions
-	sb.WriteString("## 使用建议\n\n")
-	sb.WriteString("### 查询场景\n\n")
-	sb.WriteString("1. **获取所有对象定义**\n")
-	sb.WriteString("   - 查看 `object_types/` 目录下的文件\n\n")
-	sb.WriteString("2. **查找关系定义**\n")
-	sb.WriteString("   - 查看 `relation_types/` 目录下的文件\n\n")
+	_, _ = fmt.Fprintf(&sb, "## 使用建议\n\n")
+	_, _ = fmt.Fprintf(&sb, "### 查询场景\n\n")
+	_, _ = fmt.Fprintf(&sb, "1. **获取所有对象定义**\n")
+	_, _ = fmt.Fprintf(&sb, "   - 查看 `object_types/` 目录下的文件\n\n")
+	_, _ = fmt.Fprintf(&sb, "2. **查找关系定义**\n")
+	_, _ = fmt.Fprintf(&sb, "   - 查看 `relation_types/` 目录下的文件\n\n")
 	if len(doc.ActionTypes) > 0 {
-		sb.WriteString("### 运维场景\n\n")
-		sb.WriteString("1. **执行运维操作**\n")
-		sb.WriteString("   - 查看 `action_types/` 目录下的行动定义\n")
-		sb.WriteString("   - 了解触发条件和参数绑定\n\n")
+		_, _ = fmt.Fprintf(&sb, "### 运维场景\n\n")
+		_, _ = fmt.Fprintf(&sb, "1. **执行运维操作**\n")
+		_, _ = fmt.Fprintf(&sb, "   - 查看 `action_types/` 目录下的行动定义\n")
+		_, _ = fmt.Fprintf(&sb, "   - 了解触发条件和参数绑定\n\n")
 	}
 
 	// Index tables
-	sb.WriteString("## 索引表\n\n")
-	sb.WriteString("### 按类型索引\n\n")
+	_, _ = fmt.Fprintf(&sb, "## 索引表\n\n")
+	_, _ = fmt.Fprintf(&sb, "### 按类型索引\n\n")
 	if len(doc.ObjectTypes) > 0 {
-		sb.WriteString("- **对象定义**: `object_types/`\n")
+		_, _ = fmt.Fprintf(&sb, "- **对象定义**: `object_types/`\n")
 	}
 	if len(doc.RelationTypes) > 0 {
-		sb.WriteString("- **关系定义**: `relation_types/`\n")
+		_, _ = fmt.Fprintf(&sb, "- **关系定义**: `relation_types/`\n")
 	}
 	if len(doc.ActionTypes) > 0 {
-		sb.WriteString("- **行动定义**: `action_types/`\n")
+		_, _ = fmt.Fprintf(&sb, "- **行动定义**: `action_types/`\n")
 	}
-	sb.WriteString("\n")
+	_, _ = fmt.Fprintf(&sb, "\n")
 
-	sb.WriteString("## 注意事项\n\n")
-	sb.WriteString("1. 本网络由 BKN SDK 自动生成 SKILL.md\n")
-	sb.WriteString("2. 所有定义遵循 BKN 规范\n")
-	sb.WriteString("3. 使用 CHECKSUM 文件验证网络完整性\n")
+	_, _ = fmt.Fprintf(&sb, "1. 本网络由 BKN SDK 自动生成 SKILL.md\n")
+	_, _ = fmt.Fprintf(&sb, "2. 所有定义遵循 BKN 规范\n")
+	_, _ = fmt.Fprintf(&sb, "3. 使用 CHECKSUM 文件验证网络完整性\n")
 
 	return sb.String()
 }

--- a/sdk/golang/cmd/validate-dir/main.go
+++ b/sdk/golang/cmd/validate-dir/main.go
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 // validate-dir loads a BKN directory and prints ValidateNetwork results. For ad-hoc checks.
 package main
 

--- a/sdk/golang/go.mod
+++ b/sdk/golang/go.mod
@@ -1,6 +1,6 @@
 module github.com/kweaver-ai/bkn-specification/sdk/golang
 
-go 1.24
+go 1.25
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/sdk/golang/tests/integration_test.go
+++ b/sdk/golang/tests/integration_test.go
@@ -50,7 +50,7 @@ func tempDir(t *testing.T) string {
 	t.Helper()
 	dir, err := os.MkdirTemp("", "bkn-test-*")
 	require.NoError(t, err, "create temp dir")
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	return dir
 }
 
@@ -61,7 +61,7 @@ func buildTarFromDir(t *testing.T, dir string) *bytes.Buffer {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 
-	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			return err
 		}
@@ -69,11 +69,11 @@ func buildTarFromDir(t *testing.T, dir string) *bytes.Buffer {
 		rel = filepath.ToSlash(rel)
 		data, err := os.ReadFile(path)
 		require.NoError(t, err, "read %s", path)
-		tw.WriteHeader(&tar.Header{Name: rel, Size: int64(len(data)), Mode: 0644})
-		tw.Write(data)
+		_ = tw.WriteHeader(&tar.Header{Name: rel, Size: int64(len(data)), Mode: 0644})
+		_, _ = tw.Write(data)
 		return nil
 	})
-	tw.Close()
+	_ = tw.Close()
 	return &buf
 }
 
@@ -161,8 +161,8 @@ func TestLoadFromFile(t *testing.T) {
 			doc, err := bkn.LoadNetwork(dir)
 			require.NoError(t, err, "LoadNetwork failed")
 
-			assert.NotEmpty(t, doc.BknNetworkFrontmatter.ID, "network id must not be empty")
-			assert.NotEmpty(t, doc.BknNetworkFrontmatter.Name, "network name must not be empty")
+			assert.NotEmpty(t, doc.ID, "network id must not be empty")
+			assert.NotEmpty(t, doc.Name, "network name must not be empty")
 
 			total := len(doc.ObjectTypes) + len(doc.RelationTypes) + len(doc.ActionTypes)
 			assert.Greater(t, total, 0, "expected at least one entity")
@@ -182,7 +182,7 @@ func TestLoadFromTar(t *testing.T) {
 			fileDoc, err := bkn.LoadNetwork(dir)
 			require.NoError(t, err, "load from file")
 
-			assert.Equal(t, fileDoc.BknNetworkFrontmatter.ID, tarDoc.BknNetworkFrontmatter.ID, "root ID mismatch")
+			assert.Equal(t, fileDoc.ID, tarDoc.ID, "root ID mismatch")
 			assert.Equal(t, len(fileDoc.ObjectTypes), len(tarDoc.ObjectTypes), "object count mismatch")
 			assert.Equal(t, len(fileDoc.RelationTypes), len(tarDoc.RelationTypes), "relation count mismatch")
 			assert.Equal(t, len(fileDoc.ActionTypes), len(tarDoc.ActionTypes), "action count mismatch")
@@ -208,7 +208,7 @@ func TestRoundTrip_FileContent(t *testing.T) {
 			f, err := os.Open(tarPath)
 			require.NoError(t, err, "open tar file")
 			doc, err := bkn.LoadNetworkFromTar(f)
-			f.Close()
+			_ = f.Close()
 			require.NoError(t, err, "LoadNetworkFromTar failed")
 
 			// Step 3: export the model back to a tar.
@@ -245,7 +245,7 @@ version: "1.0"
 
 	doc, err := bkn.LoadNetwork(dir)
 	require.NoError(t, err, "load empty network")
-	assert.Equal(t, "test-empty", doc.BknNetworkFrontmatter.ID)
+	assert.Equal(t, "test-empty", doc.ID)
 	assert.Empty(t, doc.ObjectTypes)
 	assert.Empty(t, doc.RelationTypes)
 	assert.Empty(t, doc.ActionTypes)
@@ -302,7 +302,7 @@ version: "1.0"
 
 	doc, err := bkn.LoadNetwork(dir)
 	require.NoError(t, err, "load network with missing subdirectories")
-	assert.Equal(t, "test-missing", doc.BknNetworkFrontmatter.ID)
+	assert.Equal(t, "test-missing", doc.ID)
 }
 
 // TestLargeNetwork: 大规模网络性能

--- a/sdk/golang/tools/regenerate_checksum.go
+++ b/sdk/golang/tools/regenerate_checksum.go
@@ -1,3 +1,10 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+//go:build ignore
+
 package main
 
 import (

--- a/sdk/golang/tools/regenerate_examples.go
+++ b/sdk/golang/tools/regenerate_examples.go
@@ -1,0 +1,101 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+//go:build ignore
+
+// Regenerate example BKN directories using the current SDK serializer.
+//
+// Usage:
+//
+//	go run regenerate_examples.go <examples-dir>
+//
+// For every immediate subdirectory of <examples-dir> that contains a
+// network.bkn, the network is loaded, re-serialized via WriteNetworkToTar,
+// and the resulting tar is extracted on top of the original directory.
+// CHECKSUM and SKILL.md are regenerated as part of the same pass.
+//
+// Run this after changing serializer output (table formatting, field
+// ordering, etc.) to keep examples/ aligned with the SDK.
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/kweaver-ai/bkn-specification/sdk/golang/bkn"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run regenerate_examples.go <examples-dir>")
+		os.Exit(1)
+	}
+
+	examplesDir := os.Args[1]
+	entries, err := os.ReadDir(examplesDir)
+	if err != nil {
+		fmt.Printf("Error reading dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(examplesDir, e.Name())
+		if _, err := os.Stat(filepath.Join(dir, "network.bkn")); err != nil {
+			continue
+		}
+
+		fmt.Printf("Regenerating %s...\n", e.Name())
+		if err := regenerate(dir); err != nil {
+			fmt.Printf("  Error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("  Done\n")
+	}
+}
+
+func regenerate(dir string) error {
+	doc, err := bkn.LoadNetwork(dir)
+	if err != nil {
+		return fmt.Errorf("load: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := bkn.WriteNetworkToTar(doc, &buf); err != nil {
+		return fmt.Errorf("write tar: %w", err)
+	}
+
+	tr := tar.NewReader(&buf)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			continue
+		}
+		dest := filepath.Join(dir, filepath.FromSlash(hdr.Name))
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+			return err
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(dest, data, 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/sdk/python/src/bkn/__init__.py
+++ b/sdk/python/src/bkn/__init__.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """BKN SDK - Parse, validate, and transform Business Knowledge Network files."""
 
 from bkn.models import (

--- a/sdk/python/src/bkn/checksum.py
+++ b/sdk/python/src/bkn/checksum.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Checksum computation and CHECKSUM generation for BKN directories."""
 
 from __future__ import annotations

--- a/sdk/python/src/bkn/delete.py
+++ b/sdk/python/src/bkn/delete.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Delete API for BKN networks. Supports planning and in-memory simulation of deletions."""
 
 from __future__ import annotations

--- a/sdk/python/src/bkn/loader.py
+++ b/sdk/python/src/bkn/loader.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Load .bkn/.bknd/.md files from disk, resolving network includes."""
 
 from __future__ import annotations

--- a/sdk/python/src/bkn/models.py
+++ b/sdk/python/src/bkn/models.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Data models for BKN documents, aligned with SPECIFICATION.md sections and table columns."""
 
 from __future__ import annotations

--- a/sdk/python/src/bkn/parser.py
+++ b/sdk/python/src/bkn/parser.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Parse .bkn/.bknd files: YAML frontmatter + Markdown body sections and tables."""
 
 from __future__ import annotations

--- a/sdk/python/src/bkn/risk/__init__.py
+++ b/sdk/python/src/bkn/risk/__init__.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Risk assessment module: compute Action risk (allow/not_allow/unknown) from __risk__-tagged definitions and context."""
 
 from bkn.risk.evaluate import ALLOW, NOT_ALLOW, UNKNOWN, RiskEvaluator, RiskResult, evaluate_risk

--- a/sdk/python/src/bkn/risk/evaluate.py
+++ b/sdk/python/src/bkn/risk/evaluate.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Evaluate whether an action is allowed in a given scenario based on risk-tagged knowledge."""
 
 from __future__ import annotations

--- a/sdk/python/src/bkn/serializer.py
+++ b/sdk/python/src/bkn/serializer.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Serialize structured data to .bknd Markdown format."""
 
 from __future__ import annotations

--- a/sdk/python/src/bkn/tar.py
+++ b/sdk/python/src/bkn/tar.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Pack BKN directory into tar archive.
 
 macOS: Sets COPYFILE_DISABLE=1 when spawning tar to prevent AppleDouble

--- a/sdk/python/src/bkn/transformers/__init__.py
+++ b/sdk/python/src/bkn/transformers/__init__.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """BKN transformers - convert BKN models to platform-specific formats."""
 
 from bkn.transformers.base import Transformer

--- a/sdk/python/src/bkn/transformers/base.py
+++ b/sdk/python/src/bkn/transformers/base.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Base transformer for converting BKN models to platform-specific formats."""
 
 from __future__ import annotations

--- a/sdk/python/src/bkn/transformers/kweaver/__init__.py
+++ b/sdk/python/src/bkn/transformers/kweaver/__init__.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Kweaver transformer and API client for ontology-manager."""
 
 from bkn.transformers.kweaver.client import KweaverClient

--- a/sdk/python/src/bkn/transformers/kweaver/client.py
+++ b/sdk/python/src/bkn/transformers/kweaver/client.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Kweaver API client for importing BKN networks."""
 
 from __future__ import annotations

--- a/sdk/python/src/bkn/transformers/kweaver/transformer.py
+++ b/sdk/python/src/bkn/transformers/kweaver/transformer.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Transform BKN models to kweaver ontology-manager API JSON.
 
 Based on ref/ontology_import_openapi_v2.json which defines three endpoints:

--- a/sdk/python/src/bkn/transformers/kweaver/types.py
+++ b/sdk/python/src/bkn/transformers/kweaver/types.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Kweaver import result and error types."""
 
 from __future__ import annotations

--- a/sdk/python/src/bkn/validator.py
+++ b/sdk/python/src/bkn/validator.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Validate .bknd DataTable rows against Object/Relation schema definitions.
 
 Checks performed:

--- a/sdk/python/tests/test_checksum.py
+++ b/sdk/python/tests/test_checksum.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Tests for bkn.checksum API."""
 
 from __future__ import annotations

--- a/sdk/python/tests/test_connection.py
+++ b/sdk/python/tests/test_connection.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Tests for optional connection support."""
 
 import pytest

--- a/sdk/python/tests/test_delete.py
+++ b/sdk/python/tests/test_delete.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Tests for bkn.delete API."""
 
 from __future__ import annotations

--- a/sdk/python/tests/test_examples_verify.py
+++ b/sdk/python/tests/test_examples_verify.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Verify all examples/*.bkn files load successfully with the SDK."""
 
 from __future__ import annotations
@@ -71,4 +76,3 @@ class TestLoadNetworks:
         assert len(net.all_objects) == 3
         assert len(net.all_relations) == 2
         assert len(net.all_actions) == 2
-

--- a/sdk/python/tests/test_kweaver.py
+++ b/sdk/python/tests/test_kweaver.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Tests for the kweaver transformer."""
 
 from __future__ import annotations

--- a/sdk/python/tests/test_loader_dir_discovery.py
+++ b/sdk/python/tests/test_loader_dir_discovery.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Tests for directory input, root file discovery, and implicit same-dir loading."""
 
 from __future__ import annotations

--- a/sdk/python/tests/test_md_compat.py
+++ b/sdk/python/tests/test_md_compat.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Tests for BKN .md carrier compatibility."""
 
 from __future__ import annotations

--- a/sdk/python/tests/test_parser.py
+++ b/sdk/python/tests/test_parser.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Tests for BKN parser using real example files."""
 
 from __future__ import annotations

--- a/sdk/python/tests/test_risk.py
+++ b/sdk/python/tests/test_risk.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Tests for the risk assessment module."""
 
 from __future__ import annotations

--- a/sdk/python/tests/test_serializer.py
+++ b/sdk/python/tests/test_serializer.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Tests for .bknd serialization (to_bknd, to_bknd_from_table)."""
 
 from __future__ import annotations

--- a/sdk/python/tests/test_tar.py
+++ b/sdk/python/tests/test_tar.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Tests for bkn.tar pack_to_tar."""
 
 from __future__ import annotations

--- a/sdk/python/tests/test_validator.py
+++ b/sdk/python/tests/test_validator.py
@@ -1,3 +1,8 @@
+# Copyright The kweaver.ai Authors.
+#
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
 """Tests for BKN data validator."""
 
 from __future__ import annotations

--- a/sdk/typescript/src/checksum/index.ts
+++ b/sdk/typescript/src/checksum/index.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 /**
  * Checksum computation and CHECKSUM generation for BKN directories.
  * Compatible with Go/examples format: {key}  sha256:{16hex}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 /**
  * BKN SDK - Parse, validate, and transform Business Knowledge Network files.
  * @packageDocumentation

--- a/sdk/typescript/src/loader/index.ts
+++ b/sdk/typescript/src/loader/index.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 /**
  * Load .bkn/.bknd/.md files from disk, resolving network includes.
  */

--- a/sdk/typescript/src/models/index.ts
+++ b/sdk/typescript/src/models/index.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 /**
  * Data models for BKN documents, aligned with SPECIFICATION.md sections.
  */

--- a/sdk/typescript/src/parser/aliases.ts
+++ b/sdk/typescript/src/parser/aliases.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 /**
  * Column and section name aliases (English canonical <-> Chinese).
  */

--- a/sdk/typescript/src/parser/blocks.ts
+++ b/sdk/typescript/src/parser/blocks.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 /**
  * Parse individual definition blocks (Object, Relation, Action, Risk, Connection).
  */

--- a/sdk/typescript/src/parser/index.ts
+++ b/sdk/typescript/src/parser/index.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 /**
  * Parse .bkn/.bknd files: YAML frontmatter + Markdown body sections and tables.
  */

--- a/sdk/typescript/src/parser/utils.ts
+++ b/sdk/typescript/src/parser/utils.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 /**
  * Low-level parsing utilities.
  */

--- a/sdk/typescript/src/tar/index.ts
+++ b/sdk/typescript/src/tar/index.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 /**
  * Pack BKN directory into tar archive.
  *

--- a/sdk/typescript/src/validator/index.ts
+++ b/sdk/typescript/src/validator/index.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 /**
  * Validate .bknd DataTable rows against Object/Relation schema definitions,
  * and structural rules (IDs, cross-references, required sections).

--- a/sdk/typescript/tests/checksum.test.ts
+++ b/sdk/typescript/tests/checksum.test.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 import { describe, it, expect } from "vitest";
 import { generateChecksum, verifyChecksum } from "../src/checksum/index.js";
 import { join } from "node:path";

--- a/sdk/typescript/tests/loader.test.ts
+++ b/sdk/typescript/tests/loader.test.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 import { describe, it, expect } from "vitest";
 import { loadBknFile, loadNetwork, discoverRootFile } from "../src/loader/index.js";
 import { join, dirname } from "node:path";

--- a/sdk/typescript/tests/parser.test.ts
+++ b/sdk/typescript/tests/parser.test.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 import { describe, it, expect } from "vitest";
 import { parseBkn, parseFrontmatter, parseBody } from "../src/parser/index.js";
 

--- a/sdk/typescript/tests/tar.test.ts
+++ b/sdk/typescript/tests/tar.test.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 import { describe, it, expect } from "vitest";
 import { packToTar } from "../src/tar/index.js";
 import { loadNetwork } from "../src/loader/index.js";

--- a/sdk/typescript/tests/validator.test.ts
+++ b/sdk/typescript/tests/validator.test.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 import { describe, it, expect } from "vitest";
 import { validateDataTable, validateNetwork } from "../src/validator/index.js";
 import type { DataTable, BknObject, BknNetwork, BknDocument } from "../src/models/index.js";

--- a/sdk/typescript/vitest.config.ts
+++ b/sdk/typescript/vitest.config.ts
@@ -1,3 +1,8 @@
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
 import { defineConfig } from "vitest/config";
 import path from "path";
 


### PR DESCRIPTION
## 变更内容

### 1. Go SDK 更新
- 更新 Go 版本至 1.25
- 优化错误处理逻辑

### 2. TypeScript SDK 更新
- 为以下文件添加 Apache License 2.0 版权头注释：
  - `src/checksum/index.ts`
  - `src/loader/index.ts`
  - `src/models/index.ts`
  - `src/parser/index.ts`
  - `src/tar/index.ts`
  - `src/validator/index.ts`
  - `tests/checksum.test.ts`
  - `tests/loader.test.ts`
  - `tests/parser.test.ts`
  - `tests/tar.test.ts`
  - `tests/validator.test.ts`
  - `vitest.config.ts`

## 检查清单
- [x] 代码变更已完成
- [x] 许可证头已正确添加
- [x] Go版本已更新