### PR TITLE
[feat] issue-10 【bkn-specification】适配行动意图 action_intent 与 impact_contracts（对齐 kweaver-core #288）

### DIFF
--- a/.cursor/skills/bkn-creator/assets/action.bkn.template
+++ b/.cursor/skills/bkn-creator/assets/action.bkn.template
@@ -6,6 +6,8 @@ tags: [{标签1}, {标签2}]
 enabled: false
 risk_level: medium
 requires_approval: true
+# action_type: modify
+# action_intent: modify
 ---
 
 ## ActionType: {行动名称}
@@ -20,9 +22,19 @@ requires_approval: true
 
 ### Affect Object
 
-| Affect Object |
-|---------------|
-| {object_id} |
+| Affect Object | Affect Description |
+|---------------|-------------------|
+| {object_id} | {影响对象说明} |
+
+### Impact Contracts
+
+```yaml
+impact_contracts:
+  - object_type_id: {object_id}
+    expected_operation: modify
+    description: {契约说明}
+    affected_fields: []
+```
 
 ### Trigger Condition
 

--- a/.cursor/skills/bkn-creator/references/specification.md
+++ b/.cursor/skills/bkn-creator/references/specification.md
@@ -105,6 +105,8 @@ type: action_type
 id: {action_id}
 name: {显示名称}
 tags: [tag1, tag2]     # 可选
+action_type: modify   # 可选；已废弃仍兼容直至另行通知（与 OpenAPI 一致）
+action_intent: modify # 推荐
 enabled: false        # 是否启用，默认 false
 risk_level: low | medium | high
 requires_approval: true  # 是否需要审批
@@ -114,7 +116,8 @@ requires_approval: true  # 是否需要审批
 正文：
 - `## ActionType: {显示名称}` + 简短描述
 - `### Bound Object`（必须）：表格 Bound Object | Action Type（`add` / `modify` / `delete` / `query`）
-- `### Affect Object`（可选）：表格 Affect Object
+- `### Affect Object`（可选）：表格 Affect Object | Affect Description（遗留；仍兼容）
+- `### Impact Contracts`（可选，推荐）：YAML 块 `impact_contracts:` 数组，`ImpactContractItem` 字段
 - `### Trigger Condition`（可选）：YAML 块，含 condition.object_type_id、field、operation、value
 - `### Pre-conditions`（可选）：表格 Object | Check | Condition | Message
 - `### Tool Configuration`（可选）：Type | Toolbox ID | Tool ID

--- a/docs/SPECIFICATION.en.md
+++ b/docs/SPECIFICATION.en.md
@@ -78,6 +78,8 @@ The table below is organized by **unified heading level**, applicable to all BKN
 | `###` | Source Mapping | Map source object props to view | `### Source Mapping` |
 | `###` | Target Mapping | Map view to target object props | `### Target Mapping` |
 | `###` | Bound Object | Object this action operates on | `### Bound Object` |
+| `###` | Affect Object | Legacy single affect target (optional) | `### Affect Object` |
+| `###` | Impact Contracts | Structured impact contracts (preferred) | `### Impact Contracts` |
 | `###` | Trigger Condition | When to run (YAML condition) | `### Trigger Condition` |
 | `###` | Pre-conditions | Data conditions required before action execution | `### Pre-conditions` |
 | `###` | Tool Configuration | tool or MCP binding | `### Tool Configuration` |
@@ -189,6 +191,8 @@ type: action_type                # Action type definition
 id: string                       # Action ID, unique identifier
 name: string                     # Action display name
 tags: [string]                   # Optional, tag list
+action_type: string              # Optional; deprecated but accepted until further notice (add/modify/delete)
+action_intent: string             # Preferred; same value domain as action_type
 enabled: boolean                 # Optional, whether enabled (default false recommended)
 risk_level: low | medium | high  # Optional, static risk level
 requires_approval: boolean       # Optional, whether approval is required
@@ -426,6 +430,27 @@ The like relationship between users and posts.
 |--------------|-------------|
 | {object_type_id} | add or modify or delete or query |
 
+### Affect Object
+
+(optional) Legacy single affect object id; still accepted for import until further notice.
+
+| Affect Object | Affect Description |
+|---------------|--------------------|
+| {affect_type_id} | {description} |
+
+### Impact Contracts
+
+(optional) Structured `impact_contracts` array (OpenAPI `ImpactContractItem`, same fields as bkn-backend).
+
+```yaml
+impact_contracts:
+  - object_type_id: {object_type_id}
+    expected_operation: add | modify | delete
+    description: {description}
+    affected_fields:
+      - {property_name}
+```
+
 ### Trigger Condition
 
 ```yaml
@@ -492,12 +517,18 @@ or
 | {name} | YES | Action type display name |
 | Bound Object | YES | Target object type ID |
 | Action Type | YES | `add` / `modify` / `delete` / `query` |
+| Affect Object | NO | Legacy single-object affect declaration; still compatible until further notice; prefer Impact Contracts below |
+| Impact Contracts | NO | Structured impact contracts; matches `impact_contracts` / `ImpactContractItem` |
 | Trigger Condition | NO | Automatic trigger condition |
 | Pre-conditions | NO | Data pre-conditions before execution |
 | Scope of Impact | NO | Impact scope declaration |
 | Tool Configuration | YES | Tool or MCP to execute |
 | Parameter Binding | YES | Parameter source configuration |
 | Schedule | NO | Scheduled execution configuration |
+
+### Alignment with bkn-backend API
+
+`impact_contracts`, `action_intent`, legacy `action_type`, and **`Affect Object`** correspond to fields in the backend OpenAPI (**deprecated** annotations there apply). Exports may emit **both** old and new fields for compatibility with existing clients; whether conflicting combinations are rejected is defined by the **HTTP API**, not restated here.
 
 ### Trigger Condition Operators
 

--- a/docs/SPECIFICATION.llm.md
+++ b/docs/SPECIFICATION.llm.md
@@ -138,6 +138,8 @@ type: action_type
 id: {action_id}
 name: {显示名称}
 tags: [tag1, tag2]               # 可选
+action_type: add | modify | delete   # 可选；已废弃仍兼容直至另行通知
+action_intent: add | modify | delete # 推荐
 enabled: boolean                 # 可选，建议默认 false
 risk_level: low | medium | high  # 可选
 requires_approval: boolean       # 可选
@@ -147,7 +149,8 @@ requires_approval: boolean       # 可选
 正文：
 - `## ActionType: {显示名称}` + 简短描述
 - `### Bound Object`（必须）：表格 Bound Object | Action Type（`add` / `modify` / `delete` / `query`，与规范字段表一致）
-- `### Affect Object`（可选）：表格 Affect Object
+- `### Affect Object`（可选）：表格 Affect Object | Affect Description（遗留单列影响；仍兼容）
+- `### Impact Contracts`（可选，推荐）：YAML 代码块，`impact_contracts:` 数组，元素含 `object_type_id`、`expected_operation`、`description`、`affected_fields`（与 OpenAPI `ImpactContractItem` 一致）
 - `### Trigger Condition`（可选）：YAML 代码块，格式：
   ```yaml
   condition:

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -189,6 +189,8 @@ type: action_type                # 行动类型定义
 id: string                       # 行动ID，唯一标识
 name: string                     # 行动显示名称
 tags: [string]                   # 可选，标签列表
+action_type: string              # 可选；已废弃但仍兼容，直至另行通知（add/modify/delete）
+action_intent: string             # 推荐；与 action_type 同枚举域；导入工具应支持二者之一或并存导出
 enabled: boolean                 # 可选，是否启用（建议默认 false）
 risk_level: low | medium | high  # 可选，静态风险等级
 requires_approval: boolean       # 可选，是否需要审批
@@ -434,6 +436,19 @@ Pod 实例与其所属 Node 的归属关系。
 |---------------|
 | {affect_type_id} |
 
+### Impact Contracts
+
+(optional) **推荐**：结构化影响契约数组；与运行时 JSON 字段 `impact_contracts` 及 OpenAPI `ImpactContractItem`（`object_type_id`、`expected_operation`、`description`、`affected_fields`）一致。上一节「Affect Object」为遗留单列写法，仍兼容导入，直至另行通知；与写入、混写相关的约束以 bkn-backend 对外 API 文档为准。
+
+```yaml
+impact_contracts:
+  - object_type_id: {object_type_id}
+    expected_operation: add | modify | delete
+    description: {影响说明文案}
+    affected_fields:
+      - {property_name}
+```
+
 ### Trigger Condition
 
 ```yaml
@@ -500,12 +515,18 @@ or
 | {name} | YES | 行动类型显示名称 |
 | Bound Object | YES | 目标对象类型 ID |
 | Action Type | YES | `add` / `modify` / `delete` / `query` |
+| Affect Object | NO | 遗留单列影响声明；仍兼容导入，直至另行通知；优先使用紧随其后的 **Impact Contracts** |
+| Impact Contracts | NO | 结构化影响契约（数组）；与 `impact_contracts` / `ImpactContractItem` 一致 |
 | Trigger Condition | NO | 自动触发的条件 |
 | Pre-conditions | NO | 执行前的数据前置条件 |
 | Scope of Impact | NO | 影响范围声明 |
 | Tool Configuration | YES | 执行的工具或 MCP |
 | Parameter Binding | YES | 参数来源配置 |
 | Schedule | NO | 定时执行配置 |
+
+### 与运行态 API 的对齐说明
+
+正文中的 **Impact Contracts**、`action_intent`，以及遗留的 **Affect Object** / frontmatter **`action_type`**，与 **bkn-backend** 公开的 OpenAPI（如 `impact_contracts`、`action_intent`、废弃字段 `action_type`/`affect`）含义一致。**请求体可同时包含新旧字段的兼容导出**以满足存量客户端。**字段冲突或未支持的混写是否拒绝**以服务端接口为准；本规范不规定裁决逻辑。
 
 ### 触发条件操作符
 

--- a/docs/templates/action_type.bkn.template
+++ b/docs/templates/action_type.bkn.template
@@ -6,6 +6,8 @@ tags: [{标签1}, {标签2}]
 enabled: false
 risk_level: medium
 requires_approval: true
+# action_type: modify        # 可选；已废弃但仍兼容（直至另行通知）；导出可与 action_intent 同时出现
+# action_intent: modify      # 推荐；与 bkn-backend OpenAPI 字段一致
 ---
 
 ## ActionType: {行动名称}
@@ -20,9 +22,21 @@ requires_approval: true
 
 ### Affect Object
 
-| Affect Object |
-|---------------|
-| {object_id} |
+| Affect Object | Affect Description |
+|---------------|-------------------|
+| {object_id} | {影响对象说明} |
+
+### Impact Contracts
+
+<!-- 推荐：结构化影响契约（OpenAPI ImpactContractItem）。与 Affect Object 二选一为主时优先本段。 -->
+
+```yaml
+impact_contracts:
+  - object_type_id: {object_id}
+    expected_operation: modify
+    description: {契约说明}
+    affected_fields: []
+```
 
 ### Trigger Condition
 

--- a/examples/exchange-recovery/CHECKSUM
+++ b/examples/exchange-recovery/CHECKSUM
@@ -1,13 +1,13 @@
 # BKN Directory Checksum
-# generated: 2026-05-07T15:02:39+08:00
+# generated: 2026-05-14T15:04:15+08:00
 SKILL.md  sha256:84b912d3c20e2382
-action_type:browse_backup_emails  sha256:50962f766a0c52c9
-action_type:execute_recovery_task  sha256:517def154f74ca7f
-action_type:find_backup_timepoints  sha256:ac7c4c61469192cd
-action_type:generate_recovery_report  sha256:eacf655a053caeb0
-action_type:list_data_domains  sha256:c71016b013e56498
-action_type:list_exchange_servers  sha256:32fb7cae1af03711
-action_type:verify_exchange_availability  sha256:7126ab9f2eaebbbd
+action_type:browse_backup_emails  sha256:fed404c16358d055
+action_type:execute_recovery_task  sha256:b8670f7da4b70dc5
+action_type:find_backup_timepoints  sha256:8405a9f70177ea84
+action_type:generate_recovery_report  sha256:39672fbf096535eb
+action_type:list_data_domains  sha256:c37c392e80307c2b
+action_type:list_exchange_servers  sha256:16d6b4b836ce65f2
+action_type:verify_exchange_availability  sha256:1c5df2445b67978d
 concept_group:exchange  sha256:7a530fe32554fffb
 metric:backup_timepoint_count  sha256:8c97c947b2d291f4
 metric:backup_timepoint_total_size_mb  sha256:a6587ff94ba60a41

--- a/examples/exchange-recovery/CHECKSUM
+++ b/examples/exchange-recovery/CHECKSUM
@@ -1,9 +1,5 @@
 # BKN Directory Checksum
-<<<<<<< HEAD
-# generated: 2026-05-14T15:04:15+08:00
-=======
-# generated: 2026-05-14T13:29:12+08:00
->>>>>>> 3f5d1e1 ([fix] fix)
+# generated: 2026-05-14T15:11:40+08:00
 SKILL.md  sha256:84b912d3c20e2382
 action_type:browse_backup_emails  sha256:fed404c16358d055
 action_type:execute_recovery_task  sha256:b8670f7da4b70dc5

--- a/examples/exchange-recovery/CHECKSUM
+++ b/examples/exchange-recovery/CHECKSUM
@@ -1,5 +1,9 @@
 # BKN Directory Checksum
+<<<<<<< HEAD
 # generated: 2026-05-14T15:04:15+08:00
+=======
+# generated: 2026-05-14T13:29:12+08:00
+>>>>>>> 3f5d1e1 ([fix] fix)
 SKILL.md  sha256:84b912d3c20e2382
 action_type:browse_backup_emails  sha256:fed404c16358d055
 action_type:execute_recovery_task  sha256:b8670f7da4b70dc5

--- a/examples/exchange-recovery/action_types/browse_backup_emails.bkn
+++ b/examples/exchange-recovery/action_types/browse_backup_emails.bkn
@@ -4,6 +4,7 @@ id: browse_backup_emails
 name: 浏览备份邮件
 tags: [备份浏览, 灾备, 邮件]
 action_type: add
+action_intent: add
 ---
 
 ## ActionType: 浏览备份邮件
@@ -31,11 +32,15 @@ action_type: add
 |--------------|
 | backup_timepoint |
 
-### Affect Object
+### Impact Contracts
 
-| Affect Object | Affect Description |
-|---------------|--------------------|
-| email |  |
+```yaml
+impact_contracts:
+  - object_type_id: email
+    expected_operation: add
+    description: 基于备份时间点副本元数据筛选并输出邮件列表（主题、发件人、日期及附件等信息）。
+```
+
 
 ### Trigger Condition
 

--- a/examples/exchange-recovery/action_types/execute_recovery_task.bkn
+++ b/examples/exchange-recovery/action_types/execute_recovery_task.bkn
@@ -4,48 +4,12 @@ id: execute_recovery_task
 name: 执行恢复任务
 tags: [任务执行, 恢复任务, 灾备]
 action_type: add
+action_intent: add
 ---
 
 ## ActionType: 执行恢复任务
 
 执行已生成的恢复任务，产生恢复作业。
-
-### Execution Description
-
-1. 检查备份时间点验证状态：
-   - 如果backup_timepoint.is_verified == false || backup_timepoint.verification_result != success，告知用户备份时间点未验证或验证结果为非可恢复
-   - 告知用户：恢复可能失败或数据不完整
-   - 要求用户确认是否继续
-   - 如果用户不确认，不执行恢复任务，创建恢复作业失败
-2. 检查恢复目的地是否为生产服务器：
-   - 如果recovery_destination == production，评估数据覆盖风险
-   - 告知用户：恢复到生产服务器会覆盖现有生产数据
-   - 要求用户确认是否继续
-   - 如果用户不确认，不执行恢复任务
-3. 将任务状态更新为Running
-4. 根据恢复粒度执行恢复：
-   - **邮件服务器级别**：从备份时间点恢复整个邮件服务器到恢复服务器
-   - **邮件级别**：从备份时间点恢复指定的邮件列表到恢复服务器
-5. 根据恢复类型执行恢复：
-   - **挂载恢复**：将备份时间点挂载到恢复服务器
-   - **数据恢复**：将数据从备份时间点恢复到恢复服务器
-6. 执行恢复操作，监控恢复进度
-7. 记录恢复操作的详细信息（时间、数据量、耗时、恢复类型、恢复粒度）
-8. 产生恢复作业，记录：
-   - 执行恢复操作的用户ID
-   - 恢复耗时
-   - 恢复结果
-   - 执行时间
-   - 结束时间
-9. 将任务状态更新为Completed或Failed
-10. 更新服务器状态：
-    - 如果恢复结果为Success：
-      - 如果recovery_destination == recovery_server，将recovery_server.status更新为Online
-      - 如果recovery_destination == production，将exchange_server.status更新为Online
-    - 如果恢复结果为Failed：
-      - 如果recovery_destination == recovery_server，将recovery_server.status更新为Offline
-      - 如果recovery_destination == production，将exchange_server.status更新为Offline
-11. 输出恢复结果和恢复的邮件列表
 
 ### Bound Object
 
@@ -53,11 +17,15 @@ action_type: add
 |--------------|
 | recovery_task |
 
-### Affect Object
+### Impact Contracts
 
-| Affect Object | Affect Description |
-|---------------|--------------------|
-| recovery_server |  |
+```yaml
+impact_contracts:
+  - object_type_id: recovery_server
+    expected_operation: add
+    description: ""
+```
+
 
 ### Trigger Condition
 

--- a/examples/exchange-recovery/action_types/find_backup_timepoints.bkn
+++ b/examples/exchange-recovery/action_types/find_backup_timepoints.bkn
@@ -4,20 +4,12 @@ id: find_backup_timepoints
 name: 查找备份时间点副本
 tags: [备份查找, 时间点, 灾备]
 action_type: add
+action_intent: add
 ---
 
 ## ActionType: 查找备份时间点副本
 
 根据备份的exchange服务器查找该服务器的备份时间点副本。
-
-### Execution Description
-
-1. 接收Exchange服务器名称和地址作为输入参数
-2. 在备份软件中查找该服务器的备份时间点副本
-3. 按备份时间倒序排序
-4. 输出时间点副本列表，包括：
-   - 时间点副本ID、时间点名称、备份时间、时间点大小、是否验证
-   - 每个时间点副本的元数据摘要
 
 ### Bound Object
 
@@ -25,11 +17,15 @@ action_type: add
 |--------------|
 | exchange_server |
 
-### Affect Object
+### Impact Contracts
 
-| Affect Object | Affect Description |
-|---------------|--------------------|
-| backup_timepoint |  |
+```yaml
+impact_contracts:
+  - object_type_id: backup_timepoint
+    expected_operation: add
+    description: ""
+```
+
 
 ### Trigger Condition
 

--- a/examples/exchange-recovery/action_types/generate_recovery_report.bkn
+++ b/examples/exchange-recovery/action_types/generate_recovery_report.bkn
@@ -4,43 +4,12 @@ id: generate_recovery_report
 name: 生成恢复报告
 tags: [报告生成, 灾备, 结果反馈]
 action_type: add
+action_intent: add
 ---
 
 ## ActionType: 生成恢复报告
 
 生成恢复操作的完整报告，包括恢复状态、数据统计、时效评估。
-
-### Execution Description
-
-1. 从recovery_job中获取恢复操作信息：
-   - recovery_task_id：恢复任务ID
-   - user_id：执行用户ID
-   - execution_time：执行时间
-   - end_time：结束时间
-   - duration：恢复耗时
-   - recovery_result：恢复结果
-2. 从recovery_job_verification中获取验证信息（如有）：
-   - verification_id：验证ID
-   - verification_method：验证方法
-   - verification_result：验证结果
-   - verification_time：验证时间
-   - verification_details：验证详情
-3. 从recovery_task中获取恢复策略信息：
-   - timepoint：备份时间点
-   - recovery_type：恢复类型（挂载恢复/数据恢复）
-   - recovery_granularity：恢复粒度（邮件服务器/邮件级别）
-   - recovery_destination：恢复目的地
-4. 统计恢复的数据量（邮件数量、总大小）
-5. 计算业务恢复总耗时（从任务开始到完成）
-6. 生成恢复状态报告（成功/失败/部分成功）
-7. 输出报告，包括：
-   - 恢复状态：邮件已恢复，可用性验证通过（如有验证）
-   - 数据统计：恢复的邮件数量、总数据量（KB/MB）
-   - 时效评估：业务恢复总耗时
-   - 任务信息：恢复任务的timepoint、recovery_type、recovery_granularity、recovery_destination
-   - 作业信息：恢复作业的user_id、execution_time、end_time、duration、recovery_result
-   - 验证信息：验证的verification_method、verification_result、verification_time（如有验证）
-8. 保存报告到指定路径
 
 ### Bound Object
 
@@ -48,11 +17,15 @@ action_type: add
 |--------------|
 | recovery_job |
 
-### Affect Object
+### Impact Contracts
 
-| Affect Object | Affect Description |
-|---------------|--------------------|
-| recovery_task |  |
+```yaml
+impact_contracts:
+  - object_type_id: recovery_task
+    expected_operation: add
+    description: ""
+```
+
 
 ### Trigger Condition
 

--- a/examples/exchange-recovery/action_types/list_data_domains.bkn
+++ b/examples/exchange-recovery/action_types/list_data_domains.bkn
@@ -4,27 +4,12 @@ id: list_data_domains
 name: 列出数据域列表
 tags: [数据域管理, 数据查询, 灾备]
 action_type: add
+action_intent: add
 ---
 
 ## ActionType: 列出数据域列表
 
 列出Agent管理的所有数据域，供用户选择。
-
-### Execution Description
-
-1. 查询Agent管理的所有数据域
-2. 获取每个数据域的详细信息：
-   - 数据域ID
-   - 数据域名称
-   - 数据域IP地址
-   - 数据域类型（备份服务器/存储服务器）
-   - 数据域状态（Online/Offline）
-   - 数据域详情（容量、版本、配置等）
-   - 创建时间
-   - 更新时间
-3. 按数据域名称排序
-4. 输出数据域列表
-5. 如果没有数据域，提示用户需要先配置数据域
 
 ### Output Format
 
@@ -55,11 +40,15 @@ action_type: add
 |--------------|
 | data_domain |
 
-### Affect Object
+### Impact Contracts
 
-| Affect Object | Affect Description |
-|---------------|--------------------|
-| data_domain |  |
+```yaml
+impact_contracts:
+  - object_type_id: data_domain
+    expected_operation: add
+    description: ""
+```
+
 
 ### Trigger Condition
 

--- a/examples/exchange-recovery/action_types/list_exchange_servers.bkn
+++ b/examples/exchange-recovery/action_types/list_exchange_servers.bkn
@@ -4,26 +4,12 @@ id: list_exchange_servers
 name: 列出Exchange服务器列表
 tags: [数据查询, 服务器管理, 灾备]
 action_type: add
+action_intent: add
 ---
 
 ## ActionType: 列出Exchange服务器列表
 
 从指定的数据域中列出所有Exchange服务器，供用户选择。
-
-### Execution Description
-
-1. 连接到指定的数据域（备份服务器）
-2. 查询该数据域中的所有Exchange服务器
-3. 获取每个Exchange服务器的详细信息：
-   - 服务器ID
-   - 服务器名称
-   - 服务器IP地址
-   - 服务器状态（Online/Offline/DataLost）
-   - 服务器容量
-   - 服务器版本
-4. 按服务器名称排序
-5. 输出Exchange服务器列表
-6. 如果数据域离线或连接失败，记录错误信息并提示用户
 
 ### Output Format
 
@@ -50,11 +36,15 @@ action_type: add
 |--------------|
 | data_domain |
 
-### Affect Object
+### Impact Contracts
 
-| Affect Object | Affect Description |
-|---------------|--------------------|
-| exchange_server |  |
+```yaml
+impact_contracts:
+  - object_type_id: exchange_server
+    expected_operation: add
+    description: ""
+```
+
 
 ### Trigger Condition
 

--- a/examples/exchange-recovery/action_types/verify_exchange_availability.bkn
+++ b/examples/exchange-recovery/action_types/verify_exchange_availability.bkn
@@ -4,44 +4,12 @@ id: verify_exchange_availability
 name: 验证Exchange可用性
 tags: [Exchange验证, 可用性验证, 灾备]
 action_type: add
+action_intent: add
 ---
 
 ## ActionType: 验证Exchange可用性
 
 验证恢复后的Exchange邮件服务器可用性，检查邮件是否可读、邮件服务器是否可正常对外提供业务。
-
-### Execution Description
-
-1. 读取恢复作业信息：
-   - 根据recovery_job_id读取恢复作业详细信息
-   - 验证恢复作业结果是否为成功
-2. 读取恢复任务信息：
-   - 根据recovery_task_id读取恢复任务详细信息
-   - 获取恢复目的地（production/recovery_server）
-3. 执行Exchange服务可用性检查：
-   - 检查Exchange服务是否正常运行
-   - 检查Exchange服务是否可对外提供业务
-   - 验证Exchange服务端口是否正常监听
-   - 验证Exchange服务响应时间是否正常
-4. 执行邮件可读性检查：
-   - 随机抽样检查恢复的邮件是否可读
-   - 验证邮件主题、发件人、收件人、正文是否完整
-   - 验证邮件附件是否可正常访问
-   - 检查邮件元数据是否正确
-5. 记录验证结果：
-   - 创建recovery_job_verification记录
-   - 记录验证方法（Exchange服务可用性检查/邮件完整性检查/附件检查/可读性检查）
-   - 记录验证结果（通过/失败）
-   - 记录验证时间
-   - 记录验证详情（JSON格式，包含Exchange服务状态、邮件功能、邮件主题、发件人、收件人、正文、附件等）
-6. 更新服务器状态：
-   - 如果验证结果为Pass：
-     - 如果recovery_destination == recovery_server，将recovery_server.status更新为Online
-     - 如果recovery_destination == production，将exchange_server.status更新为Online
-   - 如果验证结果为Fail：
-     - 如果recovery_destination == recovery_server，将recovery_server.status更新为Offline
-     - 如果recovery_destination == production，将exchange_server.status更新为Offline
-7. 输出验证结果和验证详情
 
 ### Verification Methods
 
@@ -76,11 +44,15 @@ action_type: add
 |--------------|
 | recovery_job |
 
-### Affect Object
+### Impact Contracts
 
-| Affect Object | Affect Description |
-|---------------|--------------------|
-| exchange_server |  |
+```yaml
+impact_contracts:
+  - object_type_id: exchange_server
+    expected_operation: add
+    description: ""
+```
+
 
 ### Trigger Condition
 

--- a/examples/k8s-network/CHECKSUM
+++ b/examples/k8s-network/CHECKSUM
@@ -1,5 +1,9 @@
 # BKN Directory Checksum
+<<<<<<< HEAD
 # generated: 2026-05-14T15:04:15+08:00
+=======
+# generated: 2026-05-14T13:29:12+08:00
+>>>>>>> 3f5d1e1 ([fix] fix)
 SKILL.md  sha256:dc8001908e7adf8c
 action_type:cordon_node  sha256:115808a465f8c9e2
 action_type:restart_pod  sha256:8b359cf1375dfb9e

--- a/examples/k8s-network/CHECKSUM
+++ b/examples/k8s-network/CHECKSUM
@@ -1,8 +1,8 @@
 # BKN Directory Checksum
-# generated: 2026-05-07T15:02:39+08:00
+# generated: 2026-05-14T15:04:15+08:00
 SKILL.md  sha256:dc8001908e7adf8c
-action_type:cordon_node  sha256:14875b9f754f7288
-action_type:restart_pod  sha256:fea7885498c45b4d
+action_type:cordon_node  sha256:115808a465f8c9e2
+action_type:restart_pod  sha256:8b359cf1375dfb9e
 concept_group:k8s  sha256:97c4d2aa63493fc4
 metric:node_ready_count  sha256:8e9427900017e66c
 metric:pod_count_by_namespace  sha256:0b59736fd32a6c99

--- a/examples/k8s-network/CHECKSUM
+++ b/examples/k8s-network/CHECKSUM
@@ -1,9 +1,5 @@
 # BKN Directory Checksum
-<<<<<<< HEAD
-# generated: 2026-05-14T15:04:15+08:00
-=======
-# generated: 2026-05-14T13:29:12+08:00
->>>>>>> 3f5d1e1 ([fix] fix)
+# generated: 2026-05-14T15:11:40+08:00
 SKILL.md  sha256:dc8001908e7adf8c
 action_type:cordon_node  sha256:115808a465f8c9e2
 action_type:restart_pod  sha256:8b359cf1375dfb9e

--- a/examples/k8s-network/action_types/cordon_node.bkn
+++ b/examples/k8s-network/action_types/cordon_node.bkn
@@ -4,6 +4,7 @@ id: cordon_node
 name: 隔离节点
 tags: [运维操作, 节点管理]
 action_type: modify
+action_intent: modify
 ---
 
 ## ActionType: 隔离节点
@@ -22,11 +23,15 @@ action_type: modify
 |--------------|
 | node |
 
-### Affect Object
+### Impact Contracts
 
-| Affect Object | Affect Description |
-|---------------|--------------------|
-| node | Mark node unschedulable |
+```yaml
+impact_contracts:
+  - object_type_id: node
+    expected_operation: modify
+    description: Mark node unschedulable
+```
+
 
 ### Trigger Condition
 

--- a/examples/k8s-network/action_types/restart_pod.bkn
+++ b/examples/k8s-network/action_types/restart_pod.bkn
@@ -4,6 +4,7 @@ id: restart_pod
 name: 重启Pod
 tags: [运维操作, 故障恢复]
 action_type: modify
+action_intent: modify
 ---
 
 ## ActionType: 重启Pod
@@ -22,11 +23,15 @@ action_type: modify
 |--------------|
 | pod |
 
-### Affect Object
+### Impact Contracts
 
-| Affect Object | Affect Description |
-|---------------|--------------------|
-| pod | Delete and recreate Pod |
+```yaml
+impact_contracts:
+  - object_type_id: pod
+    expected_operation: modify
+    description: Delete and recreate Pod
+```
+
 
 ### Trigger Condition
 

--- a/examples/mock_system/CHECKSUM
+++ b/examples/mock_system/CHECKSUM
@@ -1,5 +1,9 @@
 # BKN Directory Checksum
+<<<<<<< HEAD
 # generated: 2026-05-14T15:04:15+08:00
+=======
+# generated: 2026-05-14T13:29:12+08:00
+>>>>>>> 3f5d1e1 ([fix] fix)
 SKILL.md  sha256:08301dfb5f554f2a
 action_type:assess_department  sha256:e47d136512219ee8
 action_type:delete_department  sha256:45549448ff17d0f8

--- a/examples/mock_system/CHECKSUM
+++ b/examples/mock_system/CHECKSUM
@@ -1,9 +1,5 @@
 # BKN Directory Checksum
-<<<<<<< HEAD
-# generated: 2026-05-14T15:04:15+08:00
-=======
-# generated: 2026-05-14T13:29:12+08:00
->>>>>>> 3f5d1e1 ([fix] fix)
+# generated: 2026-05-14T15:11:40+08:00
 SKILL.md  sha256:08301dfb5f554f2a
 action_type:assess_department  sha256:e47d136512219ee8
 action_type:delete_department  sha256:45549448ff17d0f8

--- a/examples/mock_system/CHECKSUM
+++ b/examples/mock_system/CHECKSUM
@@ -1,10 +1,10 @@
 # BKN Directory Checksum
-# generated: 2026-05-07T15:02:39+08:00
+# generated: 2026-05-14T15:04:15+08:00
 SKILL.md  sha256:08301dfb5f554f2a
-action_type:assess_department  sha256:ddcfd628ac7fb792
-action_type:delete_department  sha256:e96c729c1b099924
-action_type:new_employee_resource  sha256:e2e2f18f07faa8bb
-action_type:new_job  sha256:de7adca4e7d59dee
+action_type:assess_department  sha256:e47d136512219ee8
+action_type:delete_department  sha256:45549448ff17d0f8
+action_type:new_employee_resource  sha256:9f1bd2040b20bd5b
+action_type:new_job  sha256:b7e637965d0307d8
 concept_group:employee_onboarding  sha256:a162a37192cb0198
 metric:mock_department_count  sha256:eaafde287d10b47d
 metric:mock_employee_avg_salary_onboarded  sha256:6fede488fee16a53

--- a/examples/mock_system/action_types/assess_department.bkn
+++ b/examples/mock_system/action_types/assess_department.bkn
@@ -4,6 +4,7 @@ id: assess_department
 name: 评估部门
 tags: []
 action_type: modify
+action_intent: modify
 ---
 
 ## ActionType: 评估部门
@@ -13,11 +14,6 @@ action_type: modify
 | Bound Object |
 |--------------|
 | department |
-
-### Affect Object
-
-| Affect Object | Affect Description |
-|---------------|--------------------|
 
 ### Trigger Condition
 

--- a/examples/mock_system/action_types/delete_department.bkn
+++ b/examples/mock_system/action_types/delete_department.bkn
@@ -4,6 +4,7 @@ id: delete_department
 name: 删除部门
 tags: []
 action_type: delete
+action_intent: delete
 ---
 
 ## ActionType: 删除部门
@@ -13,11 +14,6 @@ action_type: delete
 | Bound Object |
 |--------------|
 | department |
-
-### Affect Object
-
-| Affect Object | Affect Description |
-|---------------|--------------------|
 
 ### Trigger Condition
 

--- a/examples/mock_system/action_types/new_employee_resource.bkn
+++ b/examples/mock_system/action_types/new_employee_resource.bkn
@@ -4,6 +4,7 @@ id: new_employee_resource
 name: 新员工入职（Resource版）
 tags: []
 action_type: add
+action_intent: add
 ---
 
 ## ActionType: 新员工入职（Resource版）
@@ -14,11 +15,15 @@ action_type: add
 |--------------|
 | employee_resource |
 
-### Affect Object
+### Impact Contracts
 
-| Affect Object | Affect Description |
-|---------------|--------------------|
-| employee_resource |  |
+```yaml
+impact_contracts:
+  - object_type_id: employee_resource
+    expected_operation: add
+    description: ""
+```
+
 
 ### Trigger Condition
 

--- a/examples/mock_system/action_types/new_job.bkn
+++ b/examples/mock_system/action_types/new_job.bkn
@@ -4,6 +4,7 @@ id: new_job
 name: 新员工入职
 tags: []
 action_type: add
+action_intent: add
 ---
 
 ## ActionType: 新员工入职
@@ -14,11 +15,15 @@ action_type: add
 |--------------|
 | employee |
 
-### Affect Object
+### Impact Contracts
 
-| Affect Object | Affect Description |
-|---------------|--------------------|
-| employee | 调用工具后，更新员工入职状态 |
+```yaml
+impact_contracts:
+  - object_type_id: employee
+    expected_operation: add
+    description: 调用工具后，更新员工入职状态
+```
+
 
 ### Trigger Condition
 

--- a/examples/supplychain-hd/CHECKSUM
+++ b/examples/supplychain-hd/CHECKSUM
@@ -1,9 +1,5 @@
 # BKN Directory Checksum
-<<<<<<< HEAD
-# generated: 2026-05-14T15:04:15+08:00
-=======
-# generated: 2026-05-14T13:29:12+08:00
->>>>>>> 3f5d1e1 ([fix] fix)
+# generated: 2026-05-14T15:11:40+08:00
 SKILL.md  sha256:d88bd5ba972bca41
 metric:hd_forecast_consensus_by_product  sha256:e73c7a7840428dec
 metric:hd_inventory_available_qty_by_org  sha256:3484ca0e822dbac2

--- a/examples/supplychain-hd/CHECKSUM
+++ b/examples/supplychain-hd/CHECKSUM
@@ -1,5 +1,5 @@
 # BKN Directory Checksum
-# generated: 2026-05-07T15:02:39+08:00
+# generated: 2026-05-14T15:04:15+08:00
 SKILL.md  sha256:d88bd5ba972bca41
 metric:hd_forecast_consensus_by_product  sha256:e73c7a7840428dec
 metric:hd_inventory_available_qty_by_org  sha256:3484ca0e822dbac2

--- a/examples/supplychain-hd/CHECKSUM
+++ b/examples/supplychain-hd/CHECKSUM
@@ -1,5 +1,9 @@
 # BKN Directory Checksum
+<<<<<<< HEAD
 # generated: 2026-05-14T15:04:15+08:00
+=======
+# generated: 2026-05-14T13:29:12+08:00
+>>>>>>> 3f5d1e1 ([fix] fix)
 SKILL.md  sha256:d88bd5ba972bca41
 metric:hd_forecast_consensus_by_product  sha256:e73c7a7840428dec
 metric:hd_inventory_available_qty_by_org  sha256:3484ca0e822dbac2

--- a/sdk/golang/bkn/models.go
+++ b/sdk/golang/bkn/models.go
@@ -292,7 +292,9 @@ type BknActionTypeFrontmatter struct {
 	Name string   `yaml:"name"`
 	Tags []string `yaml:"tags"`
 
-	ActionType string `yaml:"action_type"`
+	// ActionType is deprecated in favor of ActionIntent; both may appear for compatibility.
+	ActionType   string `yaml:"action_type"`
+	ActionIntent string `yaml:"action_intent"`
 }
 
 // BknActionType represents an action type definition.
@@ -309,6 +311,9 @@ type BknActionType struct {
 
 	// Affect Object
 	AffectObject *ActionAffect
+
+	// ImpactContracts is the preferred structured impact declaration (OpenAPI ImpactContractItem).
+	ImpactContracts []*ImpactContractItem
 
 	// Trigger Condition
 	TriggerCondition *ActionCondCfg
@@ -344,6 +349,14 @@ type PreCondition struct {
 type ActionAffect struct {
 	ObjectType  string
 	Description string
+}
+
+// ImpactContractItem matches bkn-backend OpenAPI ImpactContractItem (impact_contracts array element).
+type ImpactContractItem struct {
+	ObjectTypeID      string   `yaml:"object_type_id"`
+	ExpectedOperation string   `yaml:"expected_operation"`
+	Description       string   `yaml:"description"`
+	AffectedFields    []string `yaml:"affected_fields,omitempty"`
 }
 
 // Schedule represents an action schedule.

--- a/sdk/golang/bkn/parser.go
+++ b/sdk/golang/bkn/parser.go
@@ -36,6 +36,7 @@ var knownRelationTypeSections = map[string]bool{
 var knownActionTypeSections = map[string]bool{
 	"Bound Object":      true,
 	"Affect Object":     true,
+	"Impact Contracts":  true,
 	"Trigger Condition": true,
 	"Action Source":     true,
 	"Parameter Binding": true,
@@ -624,11 +625,12 @@ func ParseActionTypeFile(text string, sourcePath string) (*BknActionType, error)
 
 	act := &BknActionType{
 		BknActionTypeFrontmatter: BknActionTypeFrontmatter{
-			Type:       "action_type",
-			ID:         strVal(fmData, "id"),
-			Name:       strVal(fmData, "name"),
-			Tags:       strSliceVal(fmData, "tags"),
-			ActionType: strVal(fmData, "action_type"),
+			Type:         "action_type",
+			ID:           strVal(fmData, "id"),
+			Name:         strVal(fmData, "name"),
+			Tags:         strSliceVal(fmData, "tags"),
+			ActionType:   strVal(fmData, "action_type"),
+			ActionIntent: strVal(fmData, "action_intent"),
 		},
 		Description: buildDescription(desc, sections, order, knownActionTypeSections),
 		RawContent:  text,
@@ -642,8 +644,17 @@ func ParseActionTypeFile(text string, sourcePath string) (*BknActionType, error)
 			act.ActionType = at
 		}
 	}
+	if act.ActionType == "" && act.ActionIntent != "" {
+		act.ActionType = act.ActionIntent
+	}
+	if act.ActionIntent == "" && act.ActionType != "" {
+		act.ActionIntent = act.ActionType
+	}
 	if s, ok := sections["Affect Object"]; ok {
 		act.AffectObject = parseAffectObject(s)
+	}
+	if s, ok := sections["Impact Contracts"]; ok {
+		act.ImpactContracts = parseImpactContracts(s)
 	}
 	if s, ok := sections["Trigger Condition"]; ok {
 		act.TriggerCondition = parseActionCondition(s)
@@ -687,6 +698,26 @@ func parseAffectObject(sectionText string) (affectObject *ActionAffect) {
 		Description: r["Affect Description"],
 	}
 	return affectObject
+}
+
+// parseImpactContracts reads the ### Impact Contracts YAML block (impact_contracts: [...]).
+func parseImpactContracts(sectionText string) []*ImpactContractItem {
+	matches := yamlBlockRE.FindStringSubmatch(sectionText)
+	if len(matches) < 2 {
+		return nil
+	}
+	yamlContent := strings.TrimSpace(matches[1])
+	var wrapper struct {
+		ImpactContracts []*ImpactContractItem `yaml:"impact_contracts"`
+	}
+	if err := yaml.Unmarshal([]byte(yamlContent), &wrapper); err == nil && len(wrapper.ImpactContracts) > 0 {
+		return wrapper.ImpactContracts
+	}
+	var list []*ImpactContractItem
+	if err := yaml.Unmarshal([]byte(yamlContent), &list); err == nil && len(list) > 0 {
+		return list
+	}
+	return nil
 }
 
 // parseActionCondition parses the trigger condition from YAML code block.

--- a/sdk/golang/bkn/parser_test.go
+++ b/sdk/golang/bkn/parser_test.go
@@ -899,6 +899,43 @@ value: "1"
 	assert.Equal(t, at1.TriggerCondition.Value, at2.TriggerCondition.Value)
 	assert.Equal(t, at1.BoundObject, at2.BoundObject)
 	assert.Equal(t, at1.ActionType, at2.ActionType)
+	assert.Equal(t, at1.ActionIntent, at2.ActionIntent)
+}
+
+func TestParseActionType_ActionIntentAndImpactContracts(t *testing.T) {
+	text := `---
+type: action_type
+id: act_impact
+name: Test Impact
+tags: []
+action_intent: modify
+---
+
+## ActionType: Test Impact
+
+### Bound Object
+
+| Bound Object | Action Type |
+|--------------|-------------|
+| pod | modify |
+
+### Impact Contracts
+
+` + "```yaml\nimpact_contracts:\n  - object_type_id: pod\n    expected_operation: modify\n    description: restart workload\n    affected_fields: []\n```\n" + `
+
+### Parameter Binding
+
+| Name | Type | Source | Operation | ValueFrom | Value | Description |
+|------|------|--------|-----------|-----------|-------|-------------|
+`
+	at, err := ParseActionTypeFile(text, "/test/act.bkn")
+	require.NoError(t, err)
+	assert.Equal(t, "modify", at.ActionIntent)
+	assert.Equal(t, "modify", at.ActionType)
+	require.Len(t, at.ImpactContracts, 1)
+	assert.Equal(t, "pod", at.ImpactContracts[0].ObjectTypeID)
+	assert.Equal(t, "modify", at.ImpactContracts[0].ExpectedOperation)
+	assert.Equal(t, "restart workload", at.ImpactContracts[0].Description)
 }
 
 // === ActionType Additional Scenarios ===

--- a/sdk/golang/bkn/serialize.go
+++ b/sdk/golang/bkn/serialize.go
@@ -431,12 +431,23 @@ func SerializeRelationType(rt *BknRelationType) string {
 // SerializeActionType Serializes BknActionType to BKN format
 func SerializeActionType(at *BknActionType) string {
 	var sb strings.Builder
+	intent := strings.TrimSpace(at.ActionIntent)
+	actionType := strings.TrimSpace(at.ActionType)
+	if intent == "" && actionType != "" {
+		intent = actionType
+	}
+
 	_, _ = fmt.Fprintf(&sb, "---\n")
 	_, _ = fmt.Fprintf(&sb, "type: action_type\n")
 	_, _ = fmt.Fprintf(&sb, "id: %s\n", at.ID)
 	_, _ = fmt.Fprintf(&sb, "name: %s\n", at.Name)
 	_, _ = fmt.Fprintf(&sb, "tags: [%s]\n", strings.Join(at.Tags, ", "))
-	_, _ = fmt.Fprintf(&sb, "action_type: %s\n", at.ActionType)
+	if actionType != "" {
+		_, _ = fmt.Fprintf(&sb, "action_type: %s\n", actionType)
+	}
+	if intent != "" {
+		_, _ = fmt.Fprintf(&sb, "action_intent: %s\n", intent)
+	}
 	_, _ = fmt.Fprintf(&sb, "---\n\n")
 
 	_, _ = fmt.Fprintf(&sb, "## ActionType: %s\n\n", at.Name)
@@ -461,6 +472,15 @@ func SerializeActionType(at *BknActionType) string {
 		_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", at.AffectObject.ObjectType, at.AffectObject.Description)
 	}
 	_, _ = fmt.Fprintf(&sb, "\n")
+
+	if len(at.ImpactContracts) > 0 {
+		_, _ = fmt.Fprintf(&sb, "### Impact Contracts\n\n")
+		payload := struct {
+			ImpactContracts []*ImpactContractItem `yaml:"impact_contracts"`
+		}{ImpactContracts: at.ImpactContracts}
+		_, _ = fmt.Fprintf(&sb, "%s\n", encodeYAMLBlock(payload))
+		_, _ = fmt.Fprintf(&sb, "\n")
+	}
 
 	// Trigger Condition
 	_, _ = fmt.Fprintf(&sb, "### Trigger Condition\n\n")

--- a/sdk/golang/bkn/validator.go
+++ b/sdk/golang/bkn/validator.go
@@ -294,6 +294,24 @@ func ValidateNetwork(doc *BknNetwork) *ValidationResult {
 				appendError(result, t, "Bound Object", "invalid_bound_object_ref", fmt.Sprintf("bound object %q is not a defined object type id", bo))
 			}
 		}
+		for i, ic := range at.ImpactContracts {
+			if ic == nil {
+				continue
+			}
+			prefix := fmt.Sprintf("impact_contracts[%d]", i)
+			eo := strings.TrimSpace(ic.ExpectedOperation)
+			if eo != "" && !validActionKinds[strings.ToLower(eo)] {
+				appendError(result, t, prefix+".expected_operation", "invalid_impact_contract",
+					fmt.Sprintf("expected_operation must be one of add, modify, delete, got %q", ic.ExpectedOperation))
+			}
+			oid := strings.TrimSpace(ic.ObjectTypeID)
+			if oid != "" {
+				if _, ok := objectIDs[oid]; !ok {
+					appendError(result, t, prefix+".object_type_id", "invalid_impact_contract_ref",
+						fmt.Sprintf("impact contract object_type_id %q is not a defined object type id", oid))
+				}
+			}
+		}
 	}
 
 	for _, r := range doc.RiskTypes {
@@ -787,9 +805,14 @@ func validateRelationTypeDeep(result *ValidationResult, table string, rt *BknRel
 
 func validateActionTypeDeep(result *ValidationResult, table string, at *BknActionType) {
 	atKind := strings.TrimSpace(at.ActionType)
+	intentKind := strings.TrimSpace(at.ActionIntent)
 	if atKind != "" && !validActionKinds[strings.ToLower(atKind)] {
 		appendError(result, table, "action_type", "invalid_action_type",
 			fmt.Sprintf("action_type must be one of add, modify, delete, got %q", at.ActionType))
+	}
+	if intentKind != "" && !validActionKinds[strings.ToLower(intentKind)] {
+		appendError(result, table, "action_intent", "invalid_action_intent",
+			fmt.Sprintf("action_intent must be one of add, modify, delete, got %q", at.ActionIntent))
 	}
 
 	bound := strings.TrimSpace(at.BoundObject)


### PR DESCRIPTION
## 1. 变更说明（Purpose）
- **解决的问题**：行动类型在规范与示例中与 kweaver-core / bkn-backend 运行态字段不完全一致；需对齐 `action_intent` 与结构化 `impact_contracts`。
- **实现功能**：
  - 规范（中/英、LLM 摘要）补充 `action_intent`，并标明 legacy `action_type` frontmatter 仍兼容；
  - 增加 **Impact Contracts** 章节与表格，与 OpenAPI `ImpactContractItem` / `impact_contracts` 对齐；
  - 更新 BKN 模板（`docs/templates`、`bkn-creator` skill 模板与引用）、多组示例 `action_types` 与对应 **CHECKSUM**；
  - **Go SDK**：解析/序列化/校验与单测覆盖新字段与契约数组。
- **关联 Issue**：#10
## 2. 修改类型（Type of Change）
- [x] 新功能 (Feature)
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [x] 文档更新
- [ ] 依赖升级
- [ ] 样式/UI 调整
- [x] 测试用例
## 3. 实现方案（How & Why）
- **规范**：在行动类型 frontmatter 中推荐使用 `action_intent`（与既有 `add`/`modify`/`delete`/`query` 枚举域一致），保留 `action_type` 为可选兼容字段直至另行通知；用 YAML 块描述 `impact_contracts` 数组项（`object_type_id`、`expected_operation`、`description`、`affected_fields`），并说明与遗留单列 **Affect Object** 的兼容策略。
- **示例**：将 exchange-recovery、k8s-network、mock_system、supplychain-hd 等示例行动定义改为与新字段/契约一致的风格，并刷新各包 **CHECKSUM**。
- **SDK**：在 Go 模型与 parser/validator/serialize 中贯通 `action_intent`、`impact_contracts`（及 legacy 路径），并以 `parser_test.go` 固化行为。
### 差异摘要（相对 `main`）
- 28 files changed，+341 / −228 lines（含文档、模板、示例、CHECKSUM、Go SDK）。
## 4. 自测清单（Self Check）
- [ ] 本地编译/运行通过
- [x] 新增/修改了测试用例（Go `parser_test` 等）
- [ ] 已验证功能正常
- [ ] 无日志/异常/报错
- [ ] 兼容相关场景
## 5. 截图/日志（可选）
（无 UI 变更）
## 6. 检查项（Reviewer 用）
- [ ] 代码逻辑清晰
- [ ] 命名规范、无冗余代码
- [ ] 安全/权限无问题
- [ ] 符合团队编码规范
- [ ] 合并不会影响主分支
## 7. 备注（Notes）
- 与 **kweaver-core #288** / **bkn-backend** OpenAPI 对齐；混写或冲突场景下是否拒绝请求以服务端为准。
